### PR TITLE
Remove future

### DIFF
--- a/brother_ql/backends/linux_kernel.py
+++ b/brother_ql/backends/linux_kernel.py
@@ -5,7 +5,6 @@ Backend to support Brother QL-series printers via the linux kernel USB printer i
 Works on Linux.
 """
 
-from __future__ import unicode_literals
 from builtins import str
 
 import glob, os, time, select

--- a/brother_ql/backends/network.py
+++ b/brother_ql/backends/network.py
@@ -5,10 +5,9 @@ Backend to support Brother QL-series printers via network.
 Works cross-platform.
 """
 
-from __future__ import unicode_literals
 from builtins import str
 
-import socket, os, time, select
+import socket, time, select
 
 from .generic import BrotherQLBackendGeneric
 

--- a/brother_ql/backends/pyusb.py
+++ b/brother_ql/backends/pyusb.py
@@ -8,7 +8,6 @@ Requires PyUSB: https://github.com/walac/pyusb/
 Install via `pip install pyusb`
 """
 
-from __future__ import unicode_literals
 from builtins import str, bytes
 
 import time

--- a/brother_ql/cli.py
+++ b/brother_ql/cli.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 # Python standard library
-from __future__ import print_function
 import logging
 
 # external dependencies

--- a/brother_ql/conversion.py
+++ b/brother_ql/conversion.py
@@ -1,14 +1,10 @@
 #!/usr/bin/env python
 
-from __future__ import division, unicode_literals
-from builtins import str
-
 import logging
 
 from PIL import Image
 import PIL.ImageOps, PIL.ImageChops
 
-from brother_ql.raster import BrotherQLRaster
 from brother_ql.devicedependent import ENDLESS_LABEL, DIE_CUT_LABEL, ROUND_DIE_CUT_LABEL, PTOUCH_ENDLESS_LABEL
 from brother_ql.devicedependent import label_type_specs, right_margin_addition
 from brother_ql import BrotherQLUnsupportedCmd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ authors = [
 license = {text = "GPL"}
 dependencies = [
     "click",
-    "future",
     "packbits",
     "pillow>=10.0.0",
     "pyusb",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(name='brother_ql',
       platforms = 'any',
       install_requires = [
           "click",
-          "future",
           "packbits",
           "pillow>=10.0.0",
           "pyusb",


### PR DESCRIPTION
Future is only needed for py2 combat - which I will remove shortly
Closes https://github.com/matmair/brother_ql-inventree/issues/40