### PR TITLE
Use Trusted publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -23,9 +26,5 @@ jobs:
       - name: Build binary
         run: |
           python3 -m build
-      - name: Publish tp PyPi
-        run: python3 -m twine upload dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-          TWINE_REPOSITORY: pypi
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "brother_ql-inventree"
-version = "1.1"
+version = "1.2a0"
 description = "Python package to talk to Brother QL label printers"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
This PR switches releases to using trusted publishers, making it simpler and securer