### PR TITLE
Report error when label is not specified

### DIFF
--- a/brother_ql/__init__.py
+++ b/brother_ql/__init__.py
@@ -1,7 +1,5 @@
-
 from .exceptions import *
 
 from .raster import BrotherQLRaster
 
 from .brother_ql_create import create_label
-

--- a/brother_ql/backends/__init__.py
+++ b/brother_ql/backends/__init__.py
@@ -1,40 +1,49 @@
-
 from .generic import BrotherQLBackendGeneric
 
 
 available_backends = [
-  'pyusb',
-  'network',
-  'linux_kernel',
+    "pyusb",
+    "network",
+    "linux_kernel",
 ]
 
+
 def guess_backend(identifier):
-    """ guess the backend from a given identifier string for the device """
-    if identifier.startswith('usb://') or identifier.startswith('0x'):
-        return 'pyusb'
-    elif identifier.startswith('file://') or identifier.startswith('/dev/usb/') or identifier.startswith('lp'):
-        return 'linux_kernel'
-    elif identifier.startswith('tcp://'):
-        return 'network'
+    """guess the backend from a given identifier string for the device"""
+    if identifier.startswith("usb://") or identifier.startswith("0x"):
+        return "pyusb"
+    elif (
+        identifier.startswith("file://")
+        or identifier.startswith("/dev/usb/")
+        or identifier.startswith("lp")
+    ):
+        return "linux_kernel"
+    elif identifier.startswith("tcp://"):
+        return "network"
     else:
-        raise ValueError('Cannot guess backend for given identifier: %s' % identifier)
-    
+        raise ValueError("Cannot guess backend for given identifier: %s" % identifier)
+
 
 def backend_factory(backend_name):
+    if backend_name == "pyusb":
+        from . import pyusb as pyusb_backend
 
-    if backend_name == 'pyusb':
-        from . import pyusb        as pyusb_backend
         list_available_devices = pyusb_backend.list_available_devices
-        backend_class          = pyusb_backend.BrotherQLBackendPyUSB
-    elif backend_name == 'linux_kernel':
+        backend_class = pyusb_backend.BrotherQLBackendPyUSB
+    elif backend_name == "linux_kernel":
         from . import linux_kernel as linux_kernel_backend
-        list_available_devices = linux_kernel_backend.list_available_devices
-        backend_class          = linux_kernel_backend.BrotherQLBackendLinuxKernel
-    elif backend_name == 'network':
-        from . import network      as network_backend
-        list_available_devices = network_backend.list_available_devices
-        backend_class          = network_backend.BrotherQLBackendNetwork
-    else:
-        raise NotImplementedError('Backend %s not implemented.' % backend_name)
 
-    return {'list_available_devices': list_available_devices, 'backend_class': backend_class}
+        list_available_devices = linux_kernel_backend.list_available_devices
+        backend_class = linux_kernel_backend.BrotherQLBackendLinuxKernel
+    elif backend_name == "network":
+        from . import network as network_backend
+
+        list_available_devices = network_backend.list_available_devices
+        backend_class = network_backend.BrotherQLBackendNetwork
+    else:
+        raise NotImplementedError("Backend %s not implemented." % backend_name)
+
+    return {
+        "list_available_devices": list_available_devices,
+        "backend_class": backend_class,
+    }

--- a/brother_ql/backends/generic.py
+++ b/brother_ql/backends/generic.py
@@ -1,25 +1,23 @@
-
-
 import logging
 
 logger = logging.getLogger(__name__)
 
+
 def list_available_devices():
-    """ List all available devices for the respective backend """
+    """List all available devices for the respective backend"""
     # returns a list of dictionaries with the keys 'identifier' and 'instance':
     # [ {'identifier': '/dev/usb/lp0', 'instance': os.open('/dev/usb/lp0', os.O_RDWR)}, ]
     raise NotImplementedError()
 
 
 class BrotherQLBackendGeneric(object):
-
     def __init__(self, device_specifier):
         """
         device_specifier can be either a string or an instance
         of the required class type.
         """
         self.write_dev = None
-        self.read_dev  = None
+        self.read_dev = None
         raise NotImplementedError()
 
     def _write(self, data):
@@ -29,16 +27,17 @@ class BrotherQLBackendGeneric(object):
         return bytes(self.read_dev.read(length))
 
     def write(self, data):
-        logger.debug('Writing %d bytes.', len(data))
+        logger.debug("Writing %d bytes.", len(data))
         self._write(data)
 
     def read(self, length=32):
         try:
             ret_bytes = self._read(length)
-            if ret_bytes: logger.debug('Read %d bytes.', len(ret_bytes))
+            if ret_bytes:
+                logger.debug("Read %d bytes.", len(ret_bytes))
             return ret_bytes
         except Exception as e:
-            logger.debug('Error reading... %s', e)
+            logger.debug("Error reading... %s", e)
             raise
 
     def dispose(self):

--- a/brother_ql/backends/helpers.py
+++ b/brother_ql/backends/helpers.py
@@ -7,7 +7,8 @@ Helpers for the subpackage brother_ql.backends
 * printing
 """
 
-import logging, time
+import logging
+import time
 
 from brother_ql.backends import backend_factory, guess_backend
 from brother_ql.reader import interpret_response

--- a/brother_ql/backends/helpers.py
+++ b/brother_ql/backends/helpers.py
@@ -14,14 +14,15 @@ from brother_ql.reader import interpret_response
 
 logger = logging.getLogger(__name__)
 
-def discover(backend_identifier='linux_kernel'):
 
+def discover(backend_identifier="linux_kernel"):
     be = backend_factory(backend_identifier)
-    list_available_devices = be['list_available_devices']
-    BrotherQLBackend       = be['backend_class']
+    list_available_devices = be["list_available_devices"]
+    BrotherQLBackend = be["backend_class"]
 
     available_devices = list_available_devices()
     return available_devices
+
 
 def send(instructions, printer_identifier=None, backend_identifier=None, blocking=True):
     """
@@ -34,11 +35,11 @@ def send(instructions, printer_identifier=None, backend_identifier=None, blockin
     """
 
     status = {
-      'instructions_sent': True, # The instructions were sent to the printer.
-      'outcome': 'unknown', # String description of the outcome of the sending operation like: 'unknown', 'sent', 'printed', 'error'
-      'printer_state': None, # If the selected backend supports reading back the printer state, this key will contain it.
-      'did_print': False, # If True, a print was produced. It defaults to False if the outcome is uncertain (due to a backend without read-back capability).
-      'ready_for_next_job': False, # If True, the printer is ready to receive the next instructions. It defaults to False if the state is unknown.
+        "instructions_sent": True,  # The instructions were sent to the printer.
+        "outcome": "unknown",  # String description of the outcome of the sending operation like: 'unknown', 'sent', 'printed', 'error'
+        "printer_state": None,  # If the selected backend supports reading back the printer state, this key will contain it.
+        "did_print": False,  # If True, a print was produced. It defaults to False if the outcome is uncertain (due to a backend without read-back capability).
+        "ready_for_next_job": False,  # If True, the printer is ready to receive the next instructions. It defaults to False if the state is unknown.
     }
     selected_backend = None
     if backend_identifier:
@@ -47,23 +48,27 @@ def send(instructions, printer_identifier=None, backend_identifier=None, blockin
         try:
             selected_backend = guess_backend(printer_identifier)
         except:
-            logger.info("No backend stated. Selecting the default linux_kernel backend.")
-            selected_backend = 'linux_kernel'
+            logger.info(
+                "No backend stated. Selecting the default linux_kernel backend."
+            )
+            selected_backend = "linux_kernel"
 
     be = backend_factory(selected_backend)
-    list_available_devices = be['list_available_devices']
-    BrotherQLBackend       = be['backend_class']
+    list_available_devices = be["list_available_devices"]
+    BrotherQLBackend = be["backend_class"]
 
     printer = BrotherQLBackend(printer_identifier)
 
     start = time.time()
-    logger.info('Sending instructions to the printer. Total: %d bytes.', len(instructions))
+    logger.info(
+        "Sending instructions to the printer. Total: %d bytes.", len(instructions)
+    )
     printer.write(instructions)
-    status['outcome'] = 'sent'
+    status["outcome"] = "sent"
 
     if not blocking:
         return status
-    if selected_backend == 'network':
+    if selected_backend == "network":
         """ No need to wait for completion. The network backend doesn't support readback. """
         return status
 
@@ -75,29 +80,34 @@ def send(instructions, printer_identifier=None, backend_identifier=None, blockin
         try:
             result = interpret_response(data)
         except ValueError:
-            logger.error("TIME %.3f - Couln't understand response: %s", time.time()-start, data)
+            logger.error(
+                "TIME %.3f - Couln't understand response: %s", time.time() - start, data
+            )
             continue
-        status['printer_state'] = result
-        logger.debug('TIME %.3f - result: %s', time.time()-start, result)
-        if result['errors']:
-            logger.error('Errors occured: %s', result['errors'])
-            status['outcome'] = 'error'
+        status["printer_state"] = result
+        logger.debug("TIME %.3f - result: %s", time.time() - start, result)
+        if result["errors"]:
+            logger.error("Errors occured: %s", result["errors"])
+            status["outcome"] = "error"
             break
-        if result['status_type'] == 'Printing completed':
-            status['did_print'] = True
-            status['outcome'] = 'printed'
-        if result['status_type'] == 'Phase change' and result['phase_type'] == 'Waiting to receive':
-            status['ready_for_next_job'] = True
-        if status['did_print'] and status['ready_for_next_job']:
+        if result["status_type"] == "Printing completed":
+            status["did_print"] = True
+            status["outcome"] = "printed"
+        if (
+            result["status_type"] == "Phase change"
+            and result["phase_type"] == "Waiting to receive"
+        ):
+            status["ready_for_next_job"] = True
+        if status["did_print"] and status["ready_for_next_job"]:
             break
 
-    if not status['did_print']:
+    if not status["did_print"]:
         logger.warning("'printing completed' status not received.")
-    if not status['ready_for_next_job']:
+    if not status["ready_for_next_job"]:
         logger.warning("'waiting to receive' status not received.")
-    if (not status['did_print']) or (not status['ready_for_next_job']):
-        logger.warning('Printing potentially not successful?')
-    if status['did_print'] and status['ready_for_next_job']:
+    if (not status["did_print"]) or (not status["ready_for_next_job"]):
+        logger.warning("Printing potentially not successful?")
+    if status["did_print"] and status["ready_for_next_job"]:
         logger.info("Printing was successful. Waiting for the next job.")
 
     return status

--- a/brother_ql/backends/helpers.py
+++ b/brother_ql/backends/helpers.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 
 
 def discover(backend_identifier="linux_kernel"):
+    if backend_identifier is None:
+        logger.info("Backend for discovery not specified, defaulting to linux_kernel")
+        backend_identifier = "linux_kernel"
     be = backend_factory(backend_identifier)
     list_available_devices = be["list_available_devices"]
     BrotherQLBackend = be["backend_class"]

--- a/brother_ql/backends/linux_kernel.py
+++ b/brother_ql/backends/linux_kernel.py
@@ -5,7 +5,10 @@ Backend to support Brother QL-series printers via the linux kernel USB printer i
 Works on Linux.
 """
 
-import glob, os, time, select
+import glob
+import os
+import time
+import select
 
 from .generic import BrotherQLBackendGeneric
 

--- a/brother_ql/backends/linux_kernel.py
+++ b/brother_ql/backends/linux_kernel.py
@@ -9,6 +9,7 @@ import glob, os, time, select
 
 from .generic import BrotherQLBackendGeneric
 
+
 def list_available_devices():
     """
     List all available devices for the linux kernel backend
@@ -18,9 +19,10 @@ def list_available_devices():
         Instance is set to None because we don't want to open (and thus potentially block) the device here.
     """
 
-    paths = glob.glob('/dev/usb/lp*')
+    paths = glob.glob("/dev/usb/lp*")
 
-    return [{'identifier': 'file://' + path, 'instance': None} for path in paths]
+    return [{"identifier": "file://" + path, "instance": None} for path in paths]
+
 
 class BrotherQLBackendLinuxKernel(BrotherQLBackendGeneric):
     """
@@ -35,38 +37,41 @@ class BrotherQLBackendLinuxKernel(BrotherQLBackendGeneric):
 
         self.read_timeout = 0.01
         # strategy : try_twice or select
-        self.strategy = 'select'
+        self.strategy = "select"
         if isinstance(device_specifier, str):
-            if device_specifier.startswith('file://'):
+            if device_specifier.startswith("file://"):
                 device_specifier = device_specifier[7:]
             self.dev = os.open(device_specifier, os.O_RDWR)
         elif isinstance(device_specifier, int):
             self.dev = device_specifier
         else:
-            raise NotImplementedError('Currently the printer can be specified either via an appropriate string or via an os.open() handle.')
+            raise NotImplementedError(
+                "Currently the printer can be specified either via an appropriate string or via an os.open() handle."
+            )
 
         self.write_dev = self.dev
-        self.read_dev  = self.dev
+        self.read_dev = self.dev
 
     def _write(self, data):
         os.write(self.write_dev, data)
 
     def _read(self, length=32):
-        if self.strategy == 'try_twice':
+        if self.strategy == "try_twice":
             data = os.read(self.read_dev, length)
             if data:
                 return data
             else:
                 time.sleep(self.read_timeout)
                 return os.read(self.read_dev, length)
-        elif self.strategy == 'select':
-            data = b''
+        elif self.strategy == "select":
+            data = b""
             start = time.time()
             while (not data) and (time.time() - start < self.read_timeout):
                 result, _, _ = select.select([self.read_dev], [], [], 0)
                 if self.read_dev in result:
                     data += os.read(self.read_dev, length)
-                if data: break
+                if data:
+                    break
                 time.sleep(0.001)
             if not data:
                 # one last try if still no data:
@@ -74,7 +79,7 @@ class BrotherQLBackendLinuxKernel(BrotherQLBackendGeneric):
             else:
                 return data
         else:
-            raise NotImplementedError('Unknown strategy')
+            raise NotImplementedError("Unknown strategy")
 
     def _dispose(self):
         os.close(self.dev)

--- a/brother_ql/backends/network.py
+++ b/brother_ql/backends/network.py
@@ -5,7 +5,9 @@ Backend to support Brother QL-series printers via network.
 Works cross-platform.
 """
 
-import socket, time, select
+import socket
+import time
+import select
 
 from .generic import BrotherQLBackendGeneric
 

--- a/brother_ql/backends/network.py
+++ b/brother_ql/backends/network.py
@@ -9,6 +9,7 @@ import socket, time, select
 
 from .generic import BrotherQLBackendGeneric
 
+
 def list_available_devices():
     """
     List all available devices for the network backend
@@ -20,7 +21,8 @@ def list_available_devices():
 
     # We need some snmp request sent to 255.255.255.255 here
     raise NotImplementedError()
-    return [{'identifier': 'tcp://' + path, 'instance': None} for path in paths]
+    return [{"identifier": "tcp://" + path, "instance": None} for path in paths]
+
 
 class BrotherQLBackendNetwork(BrotherQLBackendGeneric):
     """
@@ -35,24 +37,24 @@ class BrotherQLBackendNetwork(BrotherQLBackendGeneric):
 
         self.read_timeout = 0.01
         # strategy : try_twice, select or socket_timeout
-        self.strategy = 'socket_timeout'
+        self.strategy = "socket_timeout"
         if isinstance(device_specifier, str):
-            if device_specifier.startswith('tcp://'):
+            if device_specifier.startswith("tcp://"):
                 device_specifier = device_specifier[6:]
-            host, _, port = device_specifier.partition(':')
+            host, _, port = device_specifier.partition(":")
             if port:
                 port = int(port)
             else:
                 port = 9100
-            #try:
+            # try:
             self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             self.s.connect((host, port))
-            #except OSError as e:
+            # except OSError as e:
             #    raise ValueError('Could not connect to the device.')
-            if self.strategy == 'socket_timeout':
+            if self.strategy == "socket_timeout":
                 self.s.settimeout(self.read_timeout)
-            elif self.strategy == 'try_twice':
+            elif self.strategy == "try_twice":
                 self.s.settimeout(self.read_timeout)
             else:
                 self.s.settimeout(0)
@@ -60,7 +62,9 @@ class BrotherQLBackendNetwork(BrotherQLBackendGeneric):
         elif isinstance(device_specifier, int):
             self.dev = device_specifier
         else:
-            raise NotImplementedError('Currently the printer can be specified either via an appropriate string or via an os.open() handle.')
+            raise NotImplementedError(
+                "Currently the printer can be specified either via an appropriate string or via an os.open() handle."
+            )
 
     def _write(self, data):
         self.s.settimeout(10)
@@ -68,10 +72,10 @@ class BrotherQLBackendNetwork(BrotherQLBackendGeneric):
         self.s.settimeout(self.read_timeout)
 
     def _read(self, length=32):
-        if self.strategy in ('socket_timeout', 'try_twice'):
-            if self.strategy == 'socket_timeout':
+        if self.strategy in ("socket_timeout", "try_twice"):
+            if self.strategy == "socket_timeout":
                 tries = 1
-            if self.strategy == 'try_twice':
+            if self.strategy == "try_twice":
                 tries = 2
             for i in range(tries):
                 try:
@@ -79,19 +83,20 @@ class BrotherQLBackendNetwork(BrotherQLBackendGeneric):
                     return data
                 except socket.timeout:
                     pass
-            return b''
-        elif self.strategy == 'select':
-            data = b''
+            return b""
+        elif self.strategy == "select":
+            data = b""
             start = time.time()
             while (not data) and (time.time() - start < self.read_timeout):
                 result, _, _ = select.select([self.s], [], [], 0)
                 if self.s in result:
                     data += self.s.recv(length)
-                if data: break
+                if data:
+                    break
                 time.sleep(0.001)
             return data
         else:
-            raise NotImplementedError('Unknown strategy')
+            raise NotImplementedError("Unknown strategy")
 
     def _dispose(self):
         self.s.shutdown(socket.SHUT_RDWR)

--- a/brother_ql/backends/pyusb.py
+++ b/brother_ql/backends/pyusb.py
@@ -15,6 +15,7 @@ import usb.util
 
 from .generic import BrotherQLBackendGeneric
 
+
 def list_available_devices():
     """
     List all available devices for the respective backend
@@ -27,6 +28,7 @@ def list_available_devices():
     class find_class(object):
         def __init__(self, class_):
             self._class = class_
+
         def __call__(self, device):
             # first, let's check the device
             if device.bDeviceClass == self._class:
@@ -40,16 +42,21 @@ def list_available_devices():
             return False
 
     # only Brother printers
-    printers = usb.core.find(find_all=1, custom_match=find_class(7), idVendor=0x04f9)
+    printers = usb.core.find(find_all=1, custom_match=find_class(7), idVendor=0x04F9)
 
     def identifier(dev):
         try:
             serial = usb.util.get_string(dev, 256, dev.iSerialNumber)
-            return 'usb://0x{:04x}:0x{:04x}_{}'.format(dev.idVendor, dev.idProduct, serial)
+            return "usb://0x{:04x}:0x{:04x}_{}".format(
+                dev.idVendor, dev.idProduct, serial
+            )
         except:
-            return 'usb://0x{:04x}:0x{:04x}'.format(dev.idVendor, dev.idProduct)
+            return "usb://0x{:04x}:0x{:04x}".format(dev.idVendor, dev.idProduct)
 
-    return [{'identifier': identifier(printer), 'instance': printer} for printer in printers]
+    return [
+        {"identifier": identifier(printer), "instance": printer} for printer in printers
+    ]
+
 
 class BrotherQLBackendPyUSB(BrotherQLBackendGeneric):
     """
@@ -63,27 +70,33 @@ class BrotherQLBackendPyUSB(BrotherQLBackendGeneric):
         """
 
         self.dev = None
-        self.read_timeout =    10. # ms
-        self.write_timeout = 15000. # ms
+        self.read_timeout = 10.0  # ms
+        self.write_timeout = 15000.0  # ms
         # strategy : try_twice or select
-        self.strategy = 'try_twice'
+        self.strategy = "try_twice"
         if isinstance(device_specifier, str):
-            if device_specifier.startswith('usb://'):
+            if device_specifier.startswith("usb://"):
                 device_specifier = device_specifier[6:]
-            vendor_product, _, serial = device_specifier.partition('/')
-            vendor, _, product = vendor_product.partition(':')
+            vendor_product, _, serial = device_specifier.partition("/")
+            vendor, _, product = vendor_product.partition(":")
             vendor, product = int(vendor, 16), int(product, 16)
             for result in list_available_devices():
-                printer = result['instance']
-                if printer.idVendor == vendor and printer.idProduct == product or (serial and printer.iSerialNumber == serial):
+                printer = result["instance"]
+                if (
+                    printer.idVendor == vendor
+                    and printer.idProduct == product
+                    or (serial and printer.iSerialNumber == serial)
+                ):
                     self.dev = printer
                     break
             if self.dev is None:
-                raise ValueError('Device not found')
+                raise ValueError("Device not found")
         elif isinstance(device_specifier, usb.core.Device):
             self.dev = device_specifier
         else:
-            raise NotImplementedError('Currently the printer can be specified either via an appropriate string or via a usb.core.Device instance.')
+            raise NotImplementedError(
+                "Currently the printer can be specified either via an appropriate string or via a usb.core.Device instance."
+            )
 
         # Now we are sure to have self.dev around, start using it:
 
@@ -101,38 +114,45 @@ class BrotherQLBackendPyUSB(BrotherQLBackendGeneric):
         intf = usb.util.find_descriptor(cfg, bInterfaceClass=7)
         assert intf is not None
 
-        ep_match_in  = lambda e: usb.util.endpoint_direction(e.bEndpointAddress) == usb.util.ENDPOINT_IN
-        ep_match_out = lambda e: usb.util.endpoint_direction(e.bEndpointAddress) == usb.util.ENDPOINT_OUT
+        ep_match_in = (
+            lambda e: usb.util.endpoint_direction(e.bEndpointAddress)
+            == usb.util.ENDPOINT_IN
+        )
+        ep_match_out = (
+            lambda e: usb.util.endpoint_direction(e.bEndpointAddress)
+            == usb.util.ENDPOINT_OUT
+        )
 
-        ep_in  = usb.util.find_descriptor(intf, custom_match=ep_match_in)
+        ep_in = usb.util.find_descriptor(intf, custom_match=ep_match_in)
         ep_out = usb.util.find_descriptor(intf, custom_match=ep_match_out)
 
-        assert ep_in  is not None
+        assert ep_in is not None
         assert ep_out is not None
 
         self.write_dev = ep_out
-        self.read_dev  = ep_in
+        self.read_dev = ep_in
 
     def _raw_read(self, length):
         # pyusb Device.read() operations return array() type - let's convert it to bytes()
         return bytes(self.read_dev.read(length))
 
     def _read(self, length=32):
-        if self.strategy == 'try_twice':
+        if self.strategy == "try_twice":
             data = self._raw_read(length)
             if data:
                 return bytes(data)
             else:
-                time.sleep(self.read_timeout/1000.)
+                time.sleep(self.read_timeout / 1000.0)
                 return self._raw_read(length)
-        elif self.strategy == 'select':
-            data = b''
+        elif self.strategy == "select":
+            data = b""
             start = time.time()
-            while (not data) and (time.time() - start < self.read_timeout/1000.):
+            while (not data) and (time.time() - start < self.read_timeout / 1000.0):
                 result, _, _ = select.select([self.read_dev], [], [], 0)
                 if self.read_dev in result:
                     data += self._raw_read(length)
-                if data: break
+                if data:
+                    break
                 time.sleep(0.001)
             if not data:
                 # one last try if still no data:
@@ -140,7 +160,7 @@ class BrotherQLBackendPyUSB(BrotherQLBackendGeneric):
             else:
                 return data
         else:
-            raise NotImplementedError('Unknown strategy')
+            raise NotImplementedError("Unknown strategy")
 
     def _write(self, data):
         self.write_dev.write(data, int(self.write_timeout))

--- a/brother_ql/brother_ql_analyse.py
+++ b/brother_ql/brother_ql_analyse.py
@@ -4,14 +4,23 @@ import sys, argparse, logging
 
 from brother_ql.reader import BrotherQLReader
 
-def main():
 
+def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('file', help='The file to analyze', type=argparse.FileType('rb'))
-    parser.add_argument('--loglevel', type=lambda x: getattr(logging, x), default=logging.WARNING, help='The loglevel to apply')
+    parser.add_argument(
+        "file", help="The file to analyze", type=argparse.FileType("rb")
+    )
+    parser.add_argument(
+        "--loglevel",
+        type=lambda x: getattr(logging, x),
+        default=logging.WARNING,
+        help="The loglevel to apply",
+    )
     args = parser.parse_args()
 
-    logging.basicConfig(stream=sys.stdout, format='%(levelname)s: %(message)s', level=args.loglevel)
+    logging.basicConfig(
+        stream=sys.stdout, format="%(levelname)s: %(message)s", level=args.loglevel
+    )
 
     try:
         args.file = args.file.buffer
@@ -21,5 +30,6 @@ def main():
     br = BrotherQLReader(args.file)
     br.analyse()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/brother_ql/brother_ql_analyse.py
+++ b/brother_ql/brother_ql_analyse.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
-import sys, argparse, logging
+import sys
+import argparse
+import logging
 
 from brother_ql.reader import BrotherQLReader
 

--- a/brother_ql/brother_ql_create.py
+++ b/brother_ql/brother_ql_create.py
@@ -13,21 +13,84 @@ except:
 
 logger = logging.getLogger(__name__)
 
+
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('image', help='The image file to create a label from.')
-    parser.add_argument('outfile', nargs='?', type=argparse.FileType('wb'), default=stdout, help='The file to write the instructions to. Defaults to stdout.')
-    parser.add_argument('--model', '-m', default='QL-500', help='The printer model to use. Check available ones with `brother_ql_info list-models`.')
-    parser.add_argument('--label-size', '-s', default='62', help='The label size (and kind) to use. Check available ones with `brother_ql_info list-label-sizes`.')
-    parser.add_argument('--rotate', '-r', choices=('0', '90', '180', '270'), default='auto', help='Rotate the image (counterclock-wise) by this amount of degrees.')
-    parser.add_argument('--threshold', '-t', type=float, default=70.0, help='The threshold value (in percent) to discriminate between black and white pixels.')
-    parser.add_argument('--dither', '-d', action='store_true', help='Enable dithering when converting the image to b/w. If set, --threshold is meaningless.')
-    parser.add_argument('--compress', '-c', action='store_true', help='Enable compression (if available with the model). Takes more time but results in smaller file size.')
-    parser.add_argument('--red', action='store_true', help='Create a label to be printed on black/red/white tape (only with QL-8xx series on DK-22251 labels). You must use this option when printing on black/red tape, even when not printing red.')
-    parser.add_argument('--600dpi', action='store_true', dest='dpi_600', help='Print with 600x300 dpi available on some models. Provide your image as 600x600 dpi; perpendicular to the feeding the image will be resized to 300dpi.')
-    parser.add_argument('--lq', action='store_false', dest='hq', help='Print with low quality (faster). Default is high quality.')
-    parser.add_argument('--no-cut', dest='cut', action='store_false', help="Don't cut the tape after printing the label.")
-    parser.add_argument('--loglevel', type=lambda x: getattr(logging, x), default=logging.WARNING, help='Set to DEBUG for verbose debugging output to stderr.')
+    parser.add_argument("image", help="The image file to create a label from.")
+    parser.add_argument(
+        "outfile",
+        nargs="?",
+        type=argparse.FileType("wb"),
+        default=stdout,
+        help="The file to write the instructions to. Defaults to stdout.",
+    )
+    parser.add_argument(
+        "--model",
+        "-m",
+        default="QL-500",
+        help="The printer model to use. Check available ones with `brother_ql_info list-models`.",
+    )
+    parser.add_argument(
+        "--label-size",
+        "-s",
+        default="62",
+        help="The label size (and kind) to use. Check available ones with `brother_ql_info list-label-sizes`.",
+    )
+    parser.add_argument(
+        "--rotate",
+        "-r",
+        choices=("0", "90", "180", "270"),
+        default="auto",
+        help="Rotate the image (counterclock-wise) by this amount of degrees.",
+    )
+    parser.add_argument(
+        "--threshold",
+        "-t",
+        type=float,
+        default=70.0,
+        help="The threshold value (in percent) to discriminate between black and white pixels.",
+    )
+    parser.add_argument(
+        "--dither",
+        "-d",
+        action="store_true",
+        help="Enable dithering when converting the image to b/w. If set, --threshold is meaningless.",
+    )
+    parser.add_argument(
+        "--compress",
+        "-c",
+        action="store_true",
+        help="Enable compression (if available with the model). Takes more time but results in smaller file size.",
+    )
+    parser.add_argument(
+        "--red",
+        action="store_true",
+        help="Create a label to be printed on black/red/white tape (only with QL-8xx series on DK-22251 labels). You must use this option when printing on black/red tape, even when not printing red.",
+    )
+    parser.add_argument(
+        "--600dpi",
+        action="store_true",
+        dest="dpi_600",
+        help="Print with 600x300 dpi available on some models. Provide your image as 600x600 dpi; perpendicular to the feeding the image will be resized to 300dpi.",
+    )
+    parser.add_argument(
+        "--lq",
+        action="store_false",
+        dest="hq",
+        help="Print with low quality (faster). Default is high quality.",
+    )
+    parser.add_argument(
+        "--no-cut",
+        dest="cut",
+        action="store_false",
+        help="Don't cut the tape after printing the label.",
+    )
+    parser.add_argument(
+        "--loglevel",
+        type=lambda x: getattr(logging, x),
+        default=logging.WARNING,
+        help="Set to DEBUG for verbose debugging output to stderr.",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=args.loglevel)
@@ -37,23 +100,61 @@ def main():
     try:
         qlr = BrotherQLRaster(args.model)
     except BrotherQLUnknownModel:
-        sys.exit("Unknown model. Use the command   brother_ql_info list-models   to show available models.")
+        sys.exit(
+            "Unknown model. Use the command   brother_ql_info list-models   to show available models."
+        )
 
     try:
         label_type_specs[args.label_size]
     except ValueError:
-        sys.exit("Unknown label_size. Check available sizes with the command   brother_ql_info list-label-sizes")
+        sys.exit(
+            "Unknown label_size. Check available sizes with the command   brother_ql_info list-label-sizes"
+        )
 
     qlr.exception_on_warning = True
 
-    create_label(qlr, args.image, args.label_size, threshold=args.threshold, cut=args.cut, rotate=args.rotate, dither=args.dither, compress=args.compress, red=args.red, dpi_600=args.dpi_600, hq=args.hq)
+    create_label(
+        qlr,
+        args.image,
+        args.label_size,
+        threshold=args.threshold,
+        cut=args.cut,
+        rotate=args.rotate,
+        dither=args.dither,
+        compress=args.compress,
+        red=args.red,
+        dpi_600=args.dpi_600,
+        hq=args.hq,
+    )
 
     args.outfile.write(qlr.data)
 
-def create_label(qlr, image, label_size, threshold=70, cut=True, dither=False, compress=False, red=False, **kwargs):
+
+def create_label(
+    qlr,
+    image,
+    label_size,
+    threshold=70,
+    cut=True,
+    dither=False,
+    compress=False,
+    red=False,
+    **kwargs,
+):
     if not isinstance(image, list):
         image = [image]
-    convert(qlr, image, label_size, threshold=threshold, cut=cut, dither=dither, compress=compress, red=red, **kwargs)
+    convert(
+        qlr,
+        image,
+        label_size,
+        threshold=threshold,
+        cut=cut,
+        dither=dither,
+        compress=compress,
+        red=red,
+        **kwargs,
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/brother_ql/brother_ql_create.py
+++ b/brother_ql/brother_ql_create.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
-import sys, argparse, logging
+import sys
+import argparse
+import logging
 
 from brother_ql.raster import BrotherQLRaster
 from brother_ql.conversion import convert

--- a/brother_ql/brother_ql_debug.py
+++ b/brother_ql/brother_ql_debug.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-import sys, argparse, logging, struct, io, logging, sys, os, time
-from pprint import pprint, pformat
+import argparse
+import logging
+import time
 
 from brother_ql.reader import (
     OPCODES,

--- a/brother_ql/brother_ql_debug.py
+++ b/brother_ql/brother_ql_debug.py
@@ -3,16 +3,22 @@
 import sys, argparse, logging, struct, io, logging, sys, os, time
 from pprint import pprint, pformat
 
-from brother_ql.reader import OPCODES, chunker, merge_specific_instructions, interpret_response, match_opcode, hex_format
+from brother_ql.reader import (
+    OPCODES,
+    chunker,
+    merge_specific_instructions,
+    interpret_response,
+    match_opcode,
+    hex_format,
+)
 from brother_ql.backends import backend_factory, guess_backend
 
 logger = logging.getLogger(__name__)
 
+
 class BrotherQL_USBdebug(object):
-
-    def __init__(self, dev, instructions_data, backend='linux_kernel'):
-
-        be_cls = backend_factory(backend)['backend_class']
+    def __init__(self, dev, instructions_data, backend="linux_kernel"):
+        be_cls = backend_factory(backend)["backend_class"]
         self.be = be_cls(dev)
 
         self.sleep_time = 0.0
@@ -22,58 +28,76 @@ class BrotherQL_USBdebug(object):
         self.interactive = False
         self.merge_specific_instructions = True
         if type(instructions_data) in (str,):
-            with open(instructions_data, 'rb') as f:
+            with open(instructions_data, "rb") as f:
                 self.instructions_data = f.read()
         elif type(instructions_data) in (bytes,):
             self.instructions_data = instructions_data
         else:
-            raise NotImplementedError('Only filename or bytes supported for instructions_data argument')
+            raise NotImplementedError(
+                "Only filename or bytes supported for instructions_data argument"
+            )
         response = self.be.read()
         if response:
-            logger.warning('Received response before sending instructions: {}'.format(hex_format(response)))
+            logger.warning(
+                "Received response before sending instructions: {}".format(
+                    hex_format(response)
+                )
+            )
 
     def continue_reading(self, seconds=3.0):
         start = time.time()
         while time.time() - start < seconds:
             data = self.be.read()
-            if data != b'':
+            if data != b"":
                 global_time = time.time() - self.start
-                print('TIME %.2f' % global_time)
+                print("TIME %.2f" % global_time)
                 self.log_interp_response(data)
             time.sleep(0.001)
 
     def log_interp_response(self, data):
         try:
             interp_result = interpret_response(data)
-            logger.info("Interpretation of the response: '{status_type}' (phase: {phase_type}), '{media_type}' {media_width}x{media_length} mm^2, errors: {errors}".format(**interp_result))
+            logger.info(
+                "Interpretation of the response: '{status_type}' (phase: {phase_type}), '{media_type}' {media_width}x{media_length} mm^2, errors: {errors}".format(
+                    **interp_result
+                )
+            )
         except:
             logger.error("Couln't interpret response: %s", hex_format(data))
 
     def print_and_debug(self):
-
         self.continue_reading(0.2)
 
         instructions = chunker(self.instructions_data)
-        instructions = merge_specific_instructions(instructions, join_preamble=True, join_raster=self.merge_specific_instructions)
+        instructions = merge_specific_instructions(
+            instructions,
+            join_preamble=True,
+            join_raster=self.merge_specific_instructions,
+        )
         for instruction in instructions:
             opcode = match_opcode(instruction)
             opcode_def = OPCODES[opcode]
             cmd_name = opcode_def[0]
             hex_instruction = hex_format(instruction).split()
             if len(hex_instruction) > 100:
-                hex_instruction = ' '.join(hex_instruction[0:70] + ['[...]'] + hex_instruction[-30:])
+                hex_instruction = " ".join(
+                    hex_instruction[0:70] + ["[...]"] + hex_instruction[-30:]
+                )
             else:
-                hex_instruction = ' '.join(hex_instruction)
-            logger.info("CMD {} FOUND. Instruction: {} ".format(cmd_name, hex_instruction))
-            if self.interactive: input('Continue?')
+                hex_instruction = " ".join(hex_instruction)
+            logger.info(
+                "CMD {} FOUND. Instruction: {} ".format(cmd_name, hex_instruction)
+            )
+            if self.interactive:
+                input("Continue?")
             # WRITE
             self.be.write(instruction)
             # SLEEP BEFORE READ
             time.sleep(self.sleep_before_read)
             # READ
             response = self.be.read()
-            #response += self.be.read()
-            if response != b'':
+            # response += self.be.read()
+            if response != b"":
                 logger.info("Response from the device: {}".format(hex_format(response)))
                 self.log_interp_response(response)
             # SLEEP BETWEEN INSTRUCTIONS
@@ -81,22 +105,39 @@ class BrotherQL_USBdebug(object):
 
         self.continue_reading(self.continue_reading_for)
 
-def main():
 
+def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('file', help='The file to analyze')
-    parser.add_argument('dev', help='The device to use. Can be usb://0x04f9:0x2015 or /dev/usb/lp0 for example')
-    parser.add_argument('--sleep-time', type=float, help='time in seconds to sleep between instructions')
-    parser.add_argument('--sleep-before-read', type=float, help='time in seconds to sleep before reading response')
-    parser.add_argument('--continue-reading-for', type=float, help='continue reading after sending the last commands (time in seconds)')
-    parser.add_argument('--interactive', action='store_true', help='interactive mode')
-    parser.add_argument('--split-raster', action='store_true', help='even split preamble and raster instructions into single write operations')
-    parser.add_argument('--debug', action='store_true', help='enable debug mode')
+    parser.add_argument("file", help="The file to analyze")
+    parser.add_argument(
+        "dev",
+        help="The device to use. Can be usb://0x04f9:0x2015 or /dev/usb/lp0 for example",
+    )
+    parser.add_argument(
+        "--sleep-time", type=float, help="time in seconds to sleep between instructions"
+    )
+    parser.add_argument(
+        "--sleep-before-read",
+        type=float,
+        help="time in seconds to sleep before reading response",
+    )
+    parser.add_argument(
+        "--continue-reading-for",
+        type=float,
+        help="continue reading after sending the last commands (time in seconds)",
+    )
+    parser.add_argument("--interactive", action="store_true", help="interactive mode")
+    parser.add_argument(
+        "--split-raster",
+        action="store_true",
+        help="even split preamble and raster instructions into single write operations",
+    )
+    parser.add_argument("--debug", action="store_true", help="enable debug mode")
     args = parser.parse_args()
 
     # SETUP
     loglevel = logging.DEBUG if args.debug else logging.INFO
-    logging.basicConfig(level=loglevel, format='%(levelname)s: %(message)s')
+    logging.basicConfig(level=loglevel, format="%(levelname)s: %(message)s")
 
     try:
         backend = guess_backend(args.dev)
@@ -104,15 +145,20 @@ def main():
         parser.error(e.msg)
 
     br = BrotherQL_USBdebug(args.dev, args.file, backend=backend)
-    if args.interactive: br.interactive = True
-    if args.sleep_time: br.sleep_time = args.sleep_time
-    if args.sleep_before_read: br.sleep_before_read = args.sleep_before_read
-    if args.split_raster: br.merge_specific_instructions = False
-    if args.continue_reading_for: br.continue_reading_for = args.continue_reading_for
+    if args.interactive:
+        br.interactive = True
+    if args.sleep_time:
+        br.sleep_time = args.sleep_time
+    if args.sleep_before_read:
+        br.sleep_before_read = args.sleep_before_read
+    if args.split_raster:
+        br.merge_specific_instructions = False
+    if args.continue_reading_for:
+        br.continue_reading_for = args.continue_reading_for
 
     # GO
     br.print_and_debug()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/brother_ql/brother_ql_info.py
+++ b/brother_ql/brother_ql_info.py
@@ -2,37 +2,60 @@
 
 import argparse
 
-from brother_ql.devicedependent import models, label_sizes, label_type_specs, DIE_CUT_LABEL, ENDLESS_LABEL, ROUND_DIE_CUT_LABEL
+from brother_ql.devicedependent import (
+    models,
+    label_sizes,
+    label_type_specs,
+    DIE_CUT_LABEL,
+    ENDLESS_LABEL,
+    ROUND_DIE_CUT_LABEL,
+)
+
 
 def main():
     parser = argparse.ArgumentParser()
-    subparser = parser.add_subparsers(dest='action')
-    subparser.add_parser('list-label-sizes', help='List available label sizes')
-    subparser.add_parser('list-models',      help='List available models')
+    subparser = parser.add_subparsers(dest="action")
+    subparser.add_parser("list-label-sizes", help="List available label sizes")
+    subparser.add_parser("list-models", help="List available models")
     args = parser.parse_args()
 
     if not args.action:
-        parser.error('Please choose an action')
+        parser.error("Please choose an action")
 
-    elif args.action == 'list-models':
-        print('Supported models:')
-        for model in models: print(" " + model)
+    elif args.action == "list-models":
+        print("Supported models:")
+        for model in models:
+            print(" " + model)
 
-    elif args.action == 'list-label-sizes':
-        print('Supported label sizes:')
+    elif args.action == "list-label-sizes":
+        print("Supported label sizes:")
         fmt = " {label_size:9s} {dots_printable:14s} {label_descr:26s}"
-        print(fmt.format(label_size="Name", label_descr="Description", dots_printable="Printable px"))
+        print(
+            fmt.format(
+                label_size="Name",
+                label_descr="Description",
+                dots_printable="Printable px",
+            )
+        )
         for label_size in label_sizes:
             s = label_type_specs[label_size]
-            if s['kind'] == DIE_CUT_LABEL:
-                label_descr = "(%d x %d mm^2)"  % s['tape_size']
-                dots_printable = "{0:4d} x {1:4d}".format(*s['dots_printable'])
-            if s['kind'] == ENDLESS_LABEL:
-                label_descr = "(%d mm endless)" % s['tape_size'][0]
-                dots_printable = "{0:4d}".format(*s['dots_printable'])
-            if s['kind'] == ROUND_DIE_CUT_LABEL:
-                label_descr = "(%d mm diameter, round)" % s['tape_size'][0]
-                dots_printable = "{0:4d} x {1:4d}".format(*s['dots_printable'])
-            print(fmt.format(label_size=label_size, label_descr=label_descr, dots_printable=dots_printable))
+            if s["kind"] == DIE_CUT_LABEL:
+                label_descr = "(%d x %d mm^2)" % s["tape_size"]
+                dots_printable = "{0:4d} x {1:4d}".format(*s["dots_printable"])
+            if s["kind"] == ENDLESS_LABEL:
+                label_descr = "(%d mm endless)" % s["tape_size"][0]
+                dots_printable = "{0:4d}".format(*s["dots_printable"])
+            if s["kind"] == ROUND_DIE_CUT_LABEL:
+                label_descr = "(%d mm diameter, round)" % s["tape_size"][0]
+                dots_printable = "{0:4d} x {1:4d}".format(*s["dots_printable"])
+            print(
+                fmt.format(
+                    label_size=label_size,
+                    label_descr=label_descr,
+                    dots_printable=dots_printable,
+                )
+            )
 
-if __name__ == "__main__": main()
+
+if __name__ == "__main__":
+    main()

--- a/brother_ql/brother_ql_print.py
+++ b/brother_ql/brother_ql_print.py
@@ -4,9 +4,11 @@
 Testing the packaged version of the Linux Kernel backend
 """
 
-import argparse, logging, sys
+import argparse
+import logging
+import sys
 
-from brother_ql.backends import backend_factory, guess_backend, available_backends
+from brother_ql.backends import guess_backend, available_backends
 from brother_ql.backends.helpers import discover, send
 from brother_ql.output_helpers import (
     log_discovered_devices,

--- a/brother_ql/brother_ql_print.py
+++ b/brother_ql/brother_ql_print.py
@@ -8,35 +8,55 @@ import argparse, logging, sys
 
 from brother_ql.backends import backend_factory, guess_backend, available_backends
 from brother_ql.backends.helpers import discover, send
-from brother_ql.output_helpers import log_discovered_devices, textual_description_discovered_devices
+from brother_ql.output_helpers import (
+    log_discovered_devices,
+    textual_description_discovered_devices,
+)
 
 logger = logging.getLogger(__name__)
 
-def main():
 
+def main():
     # Command line parsing...
     parser = argparse.ArgumentParser()
-    parser.add_argument('--backend', choices=available_backends, help='Forces the use of a specific backend')
-    parser.add_argument('--list-printers', action='store_true', help='List the devices available with the selected --backend')
-    parser.add_argument('--debug', action='store_true', help='Enable debugging output')
-    parser.add_argument('instruction_file', nargs='?', help='file containing the instructions to be sent to the printer')
-    parser.add_argument('printer', metavar='PRINTER_IDENTIFIER', nargs='?', help='Identifier string specifying the printer. If not specified, selects the first detected device.')
+    parser.add_argument(
+        "--backend",
+        choices=available_backends,
+        help="Forces the use of a specific backend",
+    )
+    parser.add_argument(
+        "--list-printers",
+        action="store_true",
+        help="List the devices available with the selected --backend",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debugging output")
+    parser.add_argument(
+        "instruction_file",
+        nargs="?",
+        help="file containing the instructions to be sent to the printer",
+    )
+    parser.add_argument(
+        "printer",
+        metavar="PRINTER_IDENTIFIER",
+        nargs="?",
+        help="Identifier string specifying the printer. If not specified, selects the first detected device.",
+    )
     args = parser.parse_args()
 
     if args.list_printers and not args.backend:
-        parser.error('Please specify the backend in order to list available devices.')
+        parser.error("Please specify the backend in order to list available devices.")
 
     if not args.list_printers and not args.instruction_file:
         parser.error("the following arguments are required: instruction_file")
 
     # Reading the instruction input file into content variable
-    if args.instruction_file == '-':
+    if args.instruction_file == "-":
         try:
             content = sys.stdin.buffer.read()
         except AttributeError:
             content = sys.stdin.read()
     else:
-        with open(args.instruction_file, 'rb') as f:
+        with open(args.instruction_file, "rb") as f:
             content = f.read()
 
     # Setting up the requested level of logging.
@@ -44,8 +64,10 @@ def main():
     logging.basicConfig(level=level)
 
     # State any shortcomings of this software early on.
-    if args.backend == 'network':
-        logger.warning("The network backend doesn't supply any 'readback' functionality. No status reports will be received.")
+    if args.backend == "network":
+        logger.warning(
+            "The network backend doesn't supply any 'readback' functionality. No status reports will be received."
+        )
 
     # Select the backend based: Either explicitly stated or derived from identifier. Otherwise: Default.
     selected_backend = None
@@ -55,8 +77,10 @@ def main():
         try:
             selected_backend = guess_backend(args.printer)
         except:
-            logger.info("No backend stated. Selecting the default linux_kernel backend.")
-            selected_backend = 'linux_kernel'
+            logger.info(
+                "No backend stated. Selecting the default linux_kernel backend."
+            )
+            selected_backend = "linux_kernel"
 
     # List any printers found, if explicitly asked to do so or if no identifier has been provided.
     if args.list_printers or not args.printer:
@@ -73,13 +97,20 @@ def main():
         "We need to search for available devices and select the first."
         if not available_devices:
             sys.exit("No printer found")
-        identifier = available_devices[0]['identifier']
+        identifier = available_devices[0]["identifier"]
         print("Selecting first device %s" % identifier)
     else:
         "A string identifier for the device was given, let's use it."
         identifier = args.printer
 
     # Finally, do the actual printing.
-    send(instructions=content, printer_identifier=identifier, backend_identifier=selected_backend, blocking=True)
+    send(
+        instructions=content,
+        printer_identifier=identifier,
+        backend_identifier=selected_backend,
+        blocking=True,
+    )
 
-if __name__ == "__main__": main()
+
+if __name__ == "__main__":
+    main()

--- a/brother_ql/cli.py
+++ b/brother_ql/cli.py
@@ -7,64 +7,95 @@ import logging
 import click
 
 # imports from this very package
-from brother_ql.devicedependent import models, label_sizes, label_type_specs, DIE_CUT_LABEL, ENDLESS_LABEL, ROUND_DIE_CUT_LABEL
+from brother_ql.devicedependent import (
+    models,
+    label_sizes,
+    label_type_specs,
+    DIE_CUT_LABEL,
+    ENDLESS_LABEL,
+    ROUND_DIE_CUT_LABEL,
+)
 from brother_ql.backends import available_backends, backend_factory
 
 
-logger = logging.getLogger('brother_ql')
+logger = logging.getLogger("brother_ql")
 
 
 printer_help = "The identifier for the printer. This could be a string like tcp://192.168.1.21:9100 for a networked printer or usb://0x04f9:0x2015/000M6Z401370 for a printer connected via USB."
+
+
 @click.group()
-@click.option('-b', '--backend', type=click.Choice(available_backends), envvar='BROTHER_QL_BACKEND')
-@click.option('-m', '--model', type=click.Choice(models), envvar='BROTHER_QL_MODEL')
-@click.option('-p', '--printer', metavar='PRINTER_IDENTIFIER', envvar='BROTHER_QL_PRINTER', help=printer_help)
-@click.option('--debug', is_flag=True)
+@click.option(
+    "-b",
+    "--backend",
+    type=click.Choice(available_backends),
+    envvar="BROTHER_QL_BACKEND",
+)
+@click.option("-m", "--model", type=click.Choice(models), envvar="BROTHER_QL_MODEL")
+@click.option(
+    "-p",
+    "--printer",
+    metavar="PRINTER_IDENTIFIER",
+    envvar="BROTHER_QL_PRINTER",
+    help=printer_help,
+)
+@click.option("--debug", is_flag=True)
 @click.version_option()
 @click.pass_context
 def cli(ctx, *args, **kwargs):
-    """ Command line interface for the brother_ql Python package. """
+    """Command line interface for the brother_ql Python package."""
 
-    backend = kwargs.get('backend', None)
-    model = kwargs.get('model', None)
-    printer = kwargs.get('printer', None)
-    debug = kwargs.get('debug')
+    backend = kwargs.get("backend", None)
+    model = kwargs.get("model", None)
+    printer = kwargs.get("printer", None)
+    debug = kwargs.get("debug")
 
     # Store the general CLI options in the context meta dictionary.
     # The name corresponds to the second half of the respective envvar:
-    ctx.meta['MODEL'] = model
-    ctx.meta['BACKEND'] = backend
-    ctx.meta['PRINTER'] = printer
+    ctx.meta["MODEL"] = model
+    ctx.meta["BACKEND"] = backend
+    ctx.meta["PRINTER"] = printer
 
-    logging.basicConfig(level='DEBUG' if debug else 'INFO')
+    logging.basicConfig(level="DEBUG" if debug else "INFO")
+
 
 @cli.command()
 @click.pass_context
 def discover(ctx):
-    """ find connected label printers """
-    backend = ctx.meta.get('BACKEND', 'pyusb')
+    """find connected label printers"""
+    backend = ctx.meta.get("BACKEND", "pyusb")
     discover_and_list_available_devices(backend)
+
 
 def discover_and_list_available_devices(backend):
     from brother_ql.backends.helpers import discover
+
     available_devices = discover(backend_identifier=backend)
-    from brother_ql.output_helpers import log_discovered_devices, textual_description_discovered_devices
+    from brother_ql.output_helpers import (
+        log_discovered_devices,
+        textual_description_discovered_devices,
+    )
+
     log_discovered_devices(available_devices)
     print(textual_description_discovered_devices(available_devices))
+
 
 @cli.group()
 @click.pass_context
 def info(ctx, *args, **kwargs):
-    """ list available labels, models etc. """
+    """list available labels, models etc."""
 
-@info.command(name='models')
+
+@info.command(name="models")
 @click.pass_context
 def models_cmd(ctx, *args, **kwargs):
     """
     List the choices for --model
     """
-    print('Supported models:')
-    for model in models: print(" " + model)
+    print("Supported models:")
+    for model in models:
+        print(" " + model)
+
 
 @info.command()
 @click.pass_context
@@ -73,7 +104,9 @@ def labels(ctx, *args, **kwargs):
     List the choices for --label
     """
     from brother_ql.output_helpers import textual_label_description
+
     print(textual_label_description(label_sizes))
+
 
 @info.command()
 @click.pass_context
@@ -83,84 +116,160 @@ def env(ctx, *args, **kwargs):
     """
     import sys, platform, os, shutil
     from pkg_resources import get_distribution, working_set
+
     print("\n##################\n")
     print("Information about the running environment of brother_ql.")
     print("(Please provide this information when reporting any issue.)\n")
     # computer
     print("About the computer:")
-    for attr in ('platform', 'processor', 'release', 'system', 'machine', 'architecture'):
-        print('  * '+attr.title()+':', getattr(platform, attr)())
+    for attr in (
+        "platform",
+        "processor",
+        "release",
+        "system",
+        "machine",
+        "architecture",
+    ):
+        print("  * " + attr.title() + ":", getattr(platform, attr)())
     # Python
     print("About the installed Python version:")
-    py_version = str(sys.version).replace('\n', ' ')
+    py_version = str(sys.version).replace("\n", " ")
     print("  *", py_version)
     # brother_ql
     print("About the brother_ql package:")
-    pkg = get_distribution('brother_ql')
+    pkg = get_distribution("brother_ql")
     print("  * package location:", pkg.location)
     print("  * package version: ", pkg.version)
     try:
-        cli_loc = shutil.which('brother_ql')
+        cli_loc = shutil.which("brother_ql")
     except:
-        cli_loc = 'unknown'
+        cli_loc = "unknown"
     print("  * brother_ql CLI path:", cli_loc)
     # brother_ql's requirements
     print("About the requirements of brother_ql:")
     fmt = "  {req:14s} | {spec:10s} | {ins_vers:17s}"
-    print(fmt.format(req='requirement', spec='requested', ins_vers='installed version'))
-    print(fmt.format(req='-' * 14, spec='-'*10, ins_vers='-'*17))
+    print(fmt.format(req="requirement", spec="requested", ins_vers="installed version"))
+    print(fmt.format(req="-" * 14, spec="-" * 10, ins_vers="-" * 17))
     requirements = list(pkg.requires())
     requirements.sort(key=lambda x: x.project_name)
     for req in requirements:
         proj = req.project_name
         req_pkg = get_distribution(proj)
-        spec = ' '.join(req.specs[0]) if req.specs else 'any'
+        spec = " ".join(req.specs[0]) if req.specs else "any"
         print(fmt.format(req=proj, spec=spec, ins_vers=req_pkg.version))
     print("\n##################\n")
 
-@cli.command('print', short_help='Print a label')
-@click.argument('images', nargs=-1, type=click.File('rb'), metavar='IMAGE [IMAGE] ...')
-@click.option('-l', '--label', type=click.Choice(label_sizes), envvar='BROTHER_QL_LABEL', help='The label (size, type - die-cut or endless). Run `brother_ql info labels` for a full list including ideal pixel dimensions.')
-@click.option('-r', '--rotate', type=click.Choice(('auto', '0', '90', '180', '270')), default='auto', help='Rotate the image (counterclock-wise) by this amount of degrees.')
-@click.option('-t', '--threshold', type=float, default=70.0, help='The threshold value (in percent) to discriminate between black and white pixels.')
-@click.option('-d', '--dither', is_flag=True, help='Enable dithering when converting the image to b/w. If set, --threshold is meaningless.')
-@click.option('-c', '--compress', is_flag=True, help='Enable compression (if available with the model). Label creation can take slightly longer but the resulting instruction size is normally considerably smaller.')
-@click.option('--red', is_flag=True, help='Create a label to be printed on black/red/white tape (only with QL-8xx series on DK-22251 labels). You must use this option when printing on black/red tape, even when not printing red.')
-@click.option('--600dpi', 'dpi_600', is_flag=True, help='Print with 600x300 dpi available on some models. Provide your image as 600x600 dpi; perpendicular to the feeding the image will be resized to 300dpi.')
-@click.option('--lq', is_flag=True, help='Print with low quality (faster). Default is high quality.')
-@click.option('--no-cut', is_flag=True, help="Don't cut the tape after printing the label.")
+
+@cli.command("print", short_help="Print a label")
+@click.argument("images", nargs=-1, type=click.File("rb"), metavar="IMAGE [IMAGE] ...")
+@click.option(
+    "-l",
+    "--label",
+    type=click.Choice(label_sizes),
+    envvar="BROTHER_QL_LABEL",
+    help="The label (size, type - die-cut or endless). Run `brother_ql info labels` for a full list including ideal pixel dimensions.",
+)
+@click.option(
+    "-r",
+    "--rotate",
+    type=click.Choice(("auto", "0", "90", "180", "270")),
+    default="auto",
+    help="Rotate the image (counterclock-wise) by this amount of degrees.",
+)
+@click.option(
+    "-t",
+    "--threshold",
+    type=float,
+    default=70.0,
+    help="The threshold value (in percent) to discriminate between black and white pixels.",
+)
+@click.option(
+    "-d",
+    "--dither",
+    is_flag=True,
+    help="Enable dithering when converting the image to b/w. If set, --threshold is meaningless.",
+)
+@click.option(
+    "-c",
+    "--compress",
+    is_flag=True,
+    help="Enable compression (if available with the model). Label creation can take slightly longer but the resulting instruction size is normally considerably smaller.",
+)
+@click.option(
+    "--red",
+    is_flag=True,
+    help="Create a label to be printed on black/red/white tape (only with QL-8xx series on DK-22251 labels). You must use this option when printing on black/red tape, even when not printing red.",
+)
+@click.option(
+    "--600dpi",
+    "dpi_600",
+    is_flag=True,
+    help="Print with 600x300 dpi available on some models. Provide your image as 600x600 dpi; perpendicular to the feeding the image will be resized to 300dpi.",
+)
+@click.option(
+    "--lq",
+    is_flag=True,
+    help="Print with low quality (faster). Default is high quality.",
+)
+@click.option(
+    "--no-cut", is_flag=True, help="Don't cut the tape after printing the label."
+)
 @click.pass_context
 def print_cmd(ctx, *args, **kwargs):
-    """ Print a label of the provided IMAGE. """
-    backend = ctx.meta.get('BACKEND', 'pyusb')
-    model = ctx.meta.get('MODEL')
-    printer = ctx.meta.get('PRINTER')
+    """Print a label of the provided IMAGE."""
+    backend = ctx.meta.get("BACKEND", "pyusb")
+    model = ctx.meta.get("MODEL")
+    printer = ctx.meta.get("PRINTER")
     from brother_ql.conversion import convert
     from brother_ql.backends.helpers import send
     from brother_ql.raster import BrotherQLRaster
+
     qlr = BrotherQLRaster(model)
     qlr.exception_on_warning = True
-    kwargs['cut'] = not kwargs['no_cut']
-    del kwargs['no_cut']
+    kwargs["cut"] = not kwargs["no_cut"]
+    del kwargs["no_cut"]
     instructions = convert(qlr=qlr, **kwargs)
-    send(instructions=instructions, printer_identifier=printer, backend_identifier=backend, blocking=True)
+    send(
+        instructions=instructions,
+        printer_identifier=printer,
+        backend_identifier=backend,
+        blocking=True,
+    )
 
-@cli.command(name='analyze', help='interpret a binary file containing raster instructions for the Brother QL-Series printers')
-@click.argument('instructions', type=click.File('rb'))
-@click.option('-f', '--filename-format', help="Filename format string. Default is: label{counter:04d}.png.")
+
+@cli.command(
+    name="analyze",
+    help="interpret a binary file containing raster instructions for the Brother QL-Series printers",
+)
+@click.argument("instructions", type=click.File("rb"))
+@click.option(
+    "-f",
+    "--filename-format",
+    help="Filename format string. Default is: label{counter:04d}.png.",
+)
 @click.pass_context
 def analyze_cmd(ctx, *args, **kwargs):
     from brother_ql.reader import BrotherQLReader
-    br = BrotherQLReader(kwargs.get('instructions'))
-    if kwargs.get('filename_format'): br.filename_fmt = kwargs.get('filename_format')
+
+    br = BrotherQLReader(kwargs.get("instructions"))
+    if kwargs.get("filename_format"):
+        br.filename_fmt = kwargs.get("filename_format")
     br.analyse()
 
-@cli.command(name='send', short_help='send an instruction file to the printer')
-@click.argument('instructions', type=click.File('rb'))
+
+@cli.command(name="send", short_help="send an instruction file to the printer")
+@click.argument("instructions", type=click.File("rb"))
 @click.pass_context
 def send_cmd(ctx, *args, **kwargs):
     from brother_ql.backends.helpers import send
-    send(instructions=kwargs['instructions'].read(), printer_identifier=ctx.meta.get('PRINTER'), backend_identifier=ctx.meta.get('BACKEND'), blocking=True)
 
-if __name__ == '__main__':
+    send(
+        instructions=kwargs["instructions"].read(),
+        printer_identifier=ctx.meta.get("PRINTER"),
+        backend_identifier=ctx.meta.get("BACKEND"),
+        blocking=True,
+    )
+
+
+if __name__ == "__main__":
     cli()

--- a/brother_ql/cli.py
+++ b/brother_ql/cli.py
@@ -163,6 +163,7 @@ def env(ctx, *args, **kwargs):
 @click.option(
     "-l",
     "--label",
+    required=True,
     type=click.Choice(label_sizes),
     envvar="BROTHER_QL_LABEL",
     help="The label (size, type - die-cut or endless). Run `brother_ql info labels` for a full list including ideal pixel dimensions.",

--- a/brother_ql/cli.py
+++ b/brother_ql/cli.py
@@ -10,12 +10,8 @@ import click
 from brother_ql.devicedependent import (
     models,
     label_sizes,
-    label_type_specs,
-    DIE_CUT_LABEL,
-    ENDLESS_LABEL,
-    ROUND_DIE_CUT_LABEL,
 )
-from brother_ql.backends import available_backends, backend_factory
+from brother_ql.backends import available_backends
 
 
 logger = logging.getLogger("brother_ql")
@@ -114,8 +110,10 @@ def env(ctx, *args, **kwargs):
     """
     print debug info about running environment
     """
-    import sys, platform, os, shutil
-    from pkg_resources import get_distribution, working_set
+    import sys
+    import platform
+    import shutil
+    from pkg_resources import get_distribution
 
     print("\n##################\n")
     print("Information about the running environment of brother_ql.")

--- a/brother_ql/conversion.py
+++ b/brother_ql/conversion.py
@@ -3,7 +3,8 @@
 import logging
 
 from PIL import Image
-import PIL.ImageOps, PIL.ImageChops
+import PIL.ImageOps
+import PIL.ImageChops
 
 from brother_ql.devicedependent import (
     ENDLESS_LABEL,

--- a/brother_ql/conversion.py
+++ b/brother_ql/conversion.py
@@ -5,7 +5,12 @@ import logging
 from PIL import Image
 import PIL.ImageOps, PIL.ImageChops
 
-from brother_ql.devicedependent import ENDLESS_LABEL, DIE_CUT_LABEL, ROUND_DIE_CUT_LABEL, PTOUCH_ENDLESS_LABEL
+from brother_ql.devicedependent import (
+    ENDLESS_LABEL,
+    DIE_CUT_LABEL,
+    ROUND_DIE_CUT_LABEL,
+    PTOUCH_ENDLESS_LABEL,
+)
 from brother_ql.devicedependent import label_type_specs, right_margin_addition
 from brother_ql import BrotherQLUnsupportedCmd
 from brother_ql.image_trafos import filtered_hsv
@@ -14,7 +19,8 @@ logger = logging.getLogger(__name__)
 
 logging.getLogger("PIL.PngImagePlugin").setLevel(logging.WARNING)
 
-def convert(qlr, images, label,  **kwargs):
+
+def convert(qlr, images, label, **kwargs):
     r"""Converts one or more images to a raster instruction file.
 
     :param qlr:
@@ -42,25 +48,28 @@ def convert(qlr, images, label,  **kwargs):
     """
     label_specs = label_type_specs[label]
 
-    dots_printable = label_specs['dots_printable']
-    right_margin_dots = label_specs['right_margin_dots']
+    dots_printable = label_specs["dots_printable"]
+    right_margin_dots = label_specs["right_margin_dots"]
     right_margin_dots += right_margin_addition.get(qlr.model, 0)
     device_pixel_width = qlr.get_pixel_width()
 
-    cut = kwargs.get('cut', True)
-    dither = kwargs.get('dither', False)
-    compress = kwargs.get('compress', False)
-    red = kwargs.get('red', False)
-    rotate = kwargs.get('rotate', 'auto')
-    if rotate != 'auto': rotate = int(rotate)
-    dpi_600 = kwargs.get('dpi_600', False)
-    hq = kwargs.get('hq', True)
-    threshold = kwargs.get('threshold', 70)
+    cut = kwargs.get("cut", True)
+    dither = kwargs.get("dither", False)
+    compress = kwargs.get("compress", False)
+    red = kwargs.get("red", False)
+    rotate = kwargs.get("rotate", "auto")
+    if rotate != "auto":
+        rotate = int(rotate)
+    dpi_600 = kwargs.get("dpi_600", False)
+    hq = kwargs.get("hq", True)
+    threshold = kwargs.get("threshold", 70)
     threshold = 100.0 - threshold
-    threshold = min(255, max(0, int(threshold/100.0 * 255)))
+    threshold = min(255, max(0, int(threshold / 100.0 * 255)))
 
     if red and not qlr.two_color_support:
-        raise BrotherQLUnsupportedCmd('Printing in red is not supported with the selected model.')
+        raise BrotherQLUnsupportedCmd(
+            "Printing in red is not supported with the selected model."
+        )
 
     try:
         qlr.add_switch_mode()
@@ -80,11 +89,13 @@ def convert(qlr, images, label,  **kwargs):
             try:
                 im = Image.open(image)
             except:
-                raise NotImplementedError("The image argument needs to be an Image() instance, the filename to an image, or a file handle.")
+                raise NotImplementedError(
+                    "The image argument needs to be an Image() instance, the filename to an image, or a file handle."
+                )
 
-        if im.mode.endswith('A'):
+        if im.mode.endswith("A"):
             # place in front of white background and get red of transparency
-            bg = Image.new("RGB", im.size, (255,255,255))
+            bg = Image.new("RGB", im.size, (255, 255, 255))
             bg.paste(im, im.split()[-1])
             im = bg
         elif im.mode == "P":
@@ -95,41 +106,50 @@ def convert(qlr, images, label,  **kwargs):
             im = im.convert("RGB")
 
         if dpi_600:
-            dots_expected = [el*2 for el in dots_printable]
+            dots_expected = [el * 2 for el in dots_printable]
         else:
             dots_expected = dots_printable
 
-        if label_specs['kind'] in (ENDLESS_LABEL, PTOUCH_ENDLESS_LABEL):
-            if rotate not in ('auto', 0):
+        if label_specs["kind"] in (ENDLESS_LABEL, PTOUCH_ENDLESS_LABEL):
+            if rotate not in ("auto", 0):
                 im = im.rotate(rotate, expand=True)
             if dpi_600:
-                im = im.resize((im.size[0]//2, im.size[1]))
+                im = im.resize((im.size[0] // 2, im.size[1]))
             if im.size[0] != dots_printable[0]:
                 hsize = int((dots_printable[0] / im.size[0]) * im.size[1])
                 im = im.resize((dots_printable[0], hsize), Image.LANCZOS)
-                logger.warning('Need to resize the image...')
+                logger.warning("Need to resize the image...")
             if im.size[0] < device_pixel_width:
-                new_im = Image.new(im.mode, (device_pixel_width, im.size[1]), (255,)*len(im.mode))
-                new_im.paste(im, (device_pixel_width-im.size[0]-right_margin_dots, 0))
+                new_im = Image.new(
+                    im.mode, (device_pixel_width, im.size[1]), (255,) * len(im.mode)
+                )
+                new_im.paste(
+                    im, (device_pixel_width - im.size[0] - right_margin_dots, 0)
+                )
                 im = new_im
-        elif label_specs['kind'] in (DIE_CUT_LABEL, ROUND_DIE_CUT_LABEL):
-            if rotate == 'auto':
+        elif label_specs["kind"] in (DIE_CUT_LABEL, ROUND_DIE_CUT_LABEL):
+            if rotate == "auto":
                 if im.size[0] == dots_expected[1] and im.size[1] == dots_expected[0]:
                     im = im.rotate(90, expand=True)
             elif rotate != 0:
                 im = im.rotate(rotate, expand=True)
             if im.size[0] != dots_expected[0] or im.size[1] != dots_expected[1]:
-                raise ValueError("Bad image dimensions: %s. Expecting: %s." % (im.size, dots_expected))
+                raise ValueError(
+                    "Bad image dimensions: %s. Expecting: %s."
+                    % (im.size, dots_expected)
+                )
             if dpi_600:
-                im = im.resize((im.size[0]//2, im.size[1]))
-            new_im = Image.new(im.mode, (device_pixel_width, dots_expected[1]), (255,)*len(im.mode))
-            new_im.paste(im, (device_pixel_width-im.size[0]-right_margin_dots, 0))
+                im = im.resize((im.size[0] // 2, im.size[1]))
+            new_im = Image.new(
+                im.mode, (device_pixel_width, dots_expected[1]), (255,) * len(im.mode)
+            )
+            new_im.paste(im, (device_pixel_width - im.size[0] - right_margin_dots, 0))
             im = new_im
 
         if red:
-            filter_h = lambda h: 255 if (h <  40 or h > 210) else 0
+            filter_h = lambda h: 255 if (h < 40 or h > 210) else 0
             filter_s = lambda s: 255 if s > 100 else 0
-            filter_v = lambda v: 255 if v >  80 else 0
+            filter_v = lambda v: 255 if v > 80 else 0
             red_im = filtered_hsv(im, filter_h, filter_s, filter_v)
             red_im = red_im.convert("L")
             red_im = PIL.ImageOps.invert(red_im)
@@ -137,7 +157,7 @@ def convert(qlr, images, label,  **kwargs):
 
             filter_h = lambda h: 255
             filter_s = lambda s: 255
-            filter_v = lambda v: 255 if v <  80 else 0
+            filter_v = lambda v: 255 if v < 80 else 0
             black_im = filtered_hsv(im, filter_h, filter_s, filter_v)
             black_im = black_im.convert("L")
             black_im = PIL.ImageOps.invert(black_im)
@@ -153,16 +173,16 @@ def convert(qlr, images, label,  **kwargs):
                 im = im.point(lambda x: 0 if x < threshold else 255, mode="1")
 
         qlr.add_status_information()
-        tape_size = label_specs['tape_size']
-        if label_specs['kind'] in (DIE_CUT_LABEL, ROUND_DIE_CUT_LABEL):
+        tape_size = label_specs["tape_size"]
+        if label_specs["kind"] in (DIE_CUT_LABEL, ROUND_DIE_CUT_LABEL):
             qlr.mtype = 0x0B
             qlr.mwidth = tape_size[0]
             qlr.mlength = tape_size[1]
-        elif label_specs['kind'] in (ENDLESS_LABEL, ):
+        elif label_specs["kind"] in (ENDLESS_LABEL,):
             qlr.mtype = 0x0A
             qlr.mwidth = tape_size[0]
             qlr.mlength = 0
-        elif label_specs['kind'] in (PTOUCH_ENDLESS_LABEL, ):
+        elif label_specs["kind"] in (PTOUCH_ENDLESS_LABEL,):
             qlr.mtype = 0x00
             qlr.mwidth = tape_size[0]
             qlr.mlength = 0
@@ -181,9 +201,10 @@ def convert(qlr, images, label,  **kwargs):
             qlr.add_expanded_mode()
         except BrotherQLUnsupportedCmd:
             pass
-        qlr.add_margins(label_specs['feed_margin'])
+        qlr.add_margins(label_specs["feed_margin"])
         try:
-            if compress: qlr.add_compression(True)
+            if compress:
+                qlr.add_compression(True)
         except BrotherQLUnsupportedCmd:
             pass
         if red:

--- a/brother_ql/devicedependent.py
+++ b/brother_ql/devicedependent.py
@@ -39,11 +39,22 @@ two_color_support = []
 ## Let's recreate them using the improved data structures
 ## in brother_ql.models and brother_ql.labels
 
+
 def _populate_model_legacy_structures():
     from brother_ql.models import ModelsManager
+
     global models
-    global min_max_length_dots, min_max_feed, number_bytes_per_row, right_margin_addition
-    global modesetting, cuttingsupport, expandedmode, compressionsupport, two_color_support
+    global \
+        min_max_length_dots, \
+        min_max_feed, \
+        number_bytes_per_row, \
+        right_margin_addition
+    global \
+        modesetting, \
+        cuttingsupport, \
+        expandedmode, \
+        compressionsupport, \
+        two_color_support
 
     for model in ModelsManager().iter_elements():
         models.append(model.identifier)
@@ -51,11 +62,17 @@ def _populate_model_legacy_structures():
         min_max_feed[model.identifier] = model.min_max_feed
         number_bytes_per_row[model.identifier] = model.number_bytes_per_row
         right_margin_addition[model.identifier] = model.additional_offset_r
-        if model.mode_setting: modesetting.append(model.identifier)
-        if model.cutting: cuttingsupport.append(model.identifier)
-        if model.expanded_mode: expandedmode.append(model.identifier)
-        if model.compression: compressionsupport.append(model.identifier)
-        if model.two_color: two_color_support.append(model.identifier)
+        if model.mode_setting:
+            modesetting.append(model.identifier)
+        if model.cutting:
+            cuttingsupport.append(model.identifier)
+        if model.expanded_mode:
+            expandedmode.append(model.identifier)
+        if model.compression:
+            compressionsupport.append(model.identifier)
+        if model.two_color:
+            two_color_support.append(model.identifier)
+
 
 def _populate_label_legacy_structures():
     """
@@ -66,29 +83,33 @@ def _populate_label_legacy_structures():
     global label_sizes, label_type_specs
 
     from brother_ql.labels import FormFactor
-    DIE_CUT_LABEL =       FormFactor.DIE_CUT
-    ENDLESS_LABEL =       FormFactor.ENDLESS
+
+    DIE_CUT_LABEL = FormFactor.DIE_CUT
+    ENDLESS_LABEL = FormFactor.ENDLESS
     ROUND_DIE_CUT_LABEL = FormFactor.ROUND_DIE_CUT
-    PTOUCH_ENDLESS_LABEL =FormFactor.PTOUCH_ENDLESS
+    PTOUCH_ENDLESS_LABEL = FormFactor.PTOUCH_ENDLESS
 
     from brother_ql.labels import LabelsManager
+
     lm = LabelsManager()
     label_sizes = list(lm.iter_identifiers())
     for label in lm.iter_elements():
         l = {}
-        l['name'] = label.name
-        l['kind'] = label.form_factor
-        l['color'] = label.color
-        l['tape_size'] = label.tape_size
-        l['dots_total'] = label.dots_total
-        l['dots_printable'] = label.dots_printable
-        l['right_margin_dots'] = label.offset_r
-        l['feed_margin'] = label.feed_margin
-        l['restrict_printers'] = label.restricted_to_models
+        l["name"] = label.name
+        l["kind"] = label.form_factor
+        l["color"] = label.color
+        l["tape_size"] = label.tape_size
+        l["dots_total"] = label.dots_total
+        l["dots_printable"] = label.dots_printable
+        l["right_margin_dots"] = label.offset_r
+        l["feed_margin"] = label.feed_margin
+        l["restrict_printers"] = label.restricted_to_models
         label_type_specs[label.identifier] = l
+
 
 def _populate_all_legacy_structures():
     _populate_label_legacy_structures()
     _populate_model_legacy_structures()
+
 
 _populate_all_legacy_structures()

--- a/brother_ql/exceptions.py
+++ b/brother_ql/exceptions.py
@@ -1,12 +1,14 @@
-
 class BrotherQLError(Exception):
     pass
+
 
 class BrotherQLUnsupportedCmd(BrotherQLError):
     pass
 
+
 class BrotherQLUnknownModel(BrotherQLError):
     pass
+
 
 class BrotherQLRasterError(BrotherQLError):
     pass

--- a/brother_ql/helpers.py
+++ b/brother_ql/helpers.py
@@ -1,7 +1,7 @@
-
 import logging
 
 logger = logging.getLogger(__name__)
+
 
 class ElementsManager(object):
     """
@@ -10,6 +10,7 @@ class ElementsManager(object):
     * can be compared for equality against each other
     * have the attribute .identifier
     """
+
     DEFAULT_ELEMENTS = []
     ELEMENT_NAME = "element"
 
@@ -21,16 +22,25 @@ class ElementsManager(object):
 
     def register(self, element, pos=-1):
         if element not in self._elements:
-            if pos == -1: pos = len(self._labels)
+            if pos == -1:
+                pos = len(self._labels)
             self._labels.insert(len(self._labels), label)
         else:
-            logger.warn("Won't register %s as it's already present: %s", self.ELEMENT_NAME, element)
+            logger.warn(
+                "Won't register %s as it's already present: %s",
+                self.ELEMENT_NAME,
+                element,
+            )
 
     def deregister(self, element):
         if element in self._elements:
             self._elements.remove(element)
         else:
-            logger.warn("Trying to deregister a %s that's not registered currently: %s", self.ELEMENT_NAME, label)
+            logger.warn(
+                "Trying to deregister a %s that's not registered currently: %s",
+                self.ELEMENT_NAME,
+                label,
+            )
 
     def iter_identifiers(self):
         for element in self._elements:

--- a/brother_ql/image_trafos.py
+++ b/brother_ql/image_trafos.py
@@ -1,10 +1,11 @@
 from PIL import Image
 import colorsys
 
-def filtered_hsv(im, filter_h, filter_s, filter_v, default_col=(255,255,255)):
-    """ https://stackoverflow.com/a/22237709/183995 """
 
-    hsv_im = im.convert('HSV')
+def filtered_hsv(im, filter_h, filter_s, filter_v, default_col=(255, 255, 255)):
+    """https://stackoverflow.com/a/22237709/183995"""
+
+    hsv_im = im.convert("HSV")
     H, S, V = 0, 1, 2
     hsv = hsv_im.split()
     mask_h = hsv[H].point(filter_h)

--- a/brother_ql/image_trafos.py
+++ b/brother_ql/image_trafos.py
@@ -1,5 +1,4 @@
 from PIL import Image
-import colorsys
 
 
 def filtered_hsv(im, filter_h, filter_s, filter_v, default_col=(255, 255, 255)):

--- a/brother_ql/labels.py
+++ b/brother_ql/labels.py
@@ -1,4 +1,3 @@
-
 from attr import attrs, attrib
 from typing import List, Tuple
 from enum import IntEnum
@@ -7,12 +6,14 @@ import copy
 
 from brother_ql.helpers import ElementsManager
 
+
 class FormFactor(IntEnum):
     """
     Enumeration representing the form factor of a label.
     The labels for the Brother QL series are supplied either as die-cut (pre-sized), or for more flexibility the
     continuous label tapes offer the ability to vary the label length.
     """
+
     #: rectangular die-cut labels
     DIE_CUT = 1
     #: endless (continouse) labels
@@ -22,15 +23,18 @@ class FormFactor(IntEnum):
     #: endless P-touch labels
     PTOUCH_ENDLESS = 4
 
+
 class Color(IntEnum):
     """
     Enumeration representing the colors to be printed on a label. Most labels only support printing black on white.
     Some newer ones can also print in black and red on white.
     """
+
     #: The label can be printed in black & white.
     BLACK_WHITE = 0
     #: The label can be printed in black, white & red.
     BLACK_RED_WHITE = 1
+
 
 @attrs
 class Label(object):
@@ -39,6 +43,7 @@ class Label(object):
     and what the rasterizer needs to take care of depending on the
     label choosen, should be contained in this class.
     """
+
     #: A string identifier given to each label that can be selected. Eg. '29'.
     identifier = attrib(type=str)
     #: The tape size of a single label (width, lenght) in mm. For endless labels, the length is 0 by definition.
@@ -60,64 +65,191 @@ class Label(object):
     #: Some labels allow printing in red, most don't.
     color = attrib(type=Color, default=Color.BLACK_WHITE)
 
-    def works_with_model(self, model): # type: bool
+    def works_with_model(self, model):  # type: bool
         """
         Method to determine if certain label can be printed by the specified printer model.
         """
-        if self.restricted_to_models and model not in models: return False
-        else: return True
+        if self.restricted_to_models and model not in models:
+            return False
+        else:
+            return True
 
     @property
-    def name(self): # type: str
+    def name(self):  # type: str
         out = ""
-        if 'x' in self.identifier:
-            out = '{0}mm x {1}mm die-cut'.format(*self.tape_size)
-        elif self.identifier.startswith('d'):
-            out = '{0}mm round die-cut'.format(self.tape_size[0])
+        if "x" in self.identifier:
+            out = "{0}mm x {1}mm die-cut".format(*self.tape_size)
+        elif self.identifier.startswith("d"):
+            out = "{0}mm round die-cut".format(self.tape_size[0])
         else:
-            out = '{0}mm endless'.format(self.tape_size[0])
+            out = "{0}mm endless".format(self.tape_size[0])
         if self.color == Color.BLACK_RED_WHITE:
-            out += ' (black/red/white)'
+            out += " (black/red/white)"
         return out
 
-ALL_LABELS = (
-  Label("12",     ( 12,   0), FormFactor.ENDLESS,       ( 142,    0), ( 106,    0),  29 , feed_margin=35),
-  Label("12+17",  ( 12,   0), FormFactor.ENDLESS,       ( 342,    0), ( 306,    0),  29 , feed_margin=35),
-  Label("18",     ( 18,   0), FormFactor.ENDLESS,       ( 256,    0), ( 234,    0), 171 , feed_margin=14),
-  Label("29",     ( 29,   0), FormFactor.ENDLESS,       ( 342,    0), ( 306,    0),   6 , feed_margin=35),
-  Label("38",     ( 38,   0), FormFactor.ENDLESS,       ( 449,    0), ( 413,    0),  12 , feed_margin=35),
-  Label("50",     ( 50,   0), FormFactor.ENDLESS,       ( 590,    0), ( 554,    0),  12 , feed_margin=35),
-  Label("54",     ( 54,   0), FormFactor.ENDLESS,       ( 636,    0), ( 590,    0),   0 , feed_margin=35),
-  Label("62",     ( 62,   0), FormFactor.ENDLESS,       ( 732,    0), ( 696,    0),  12 , feed_margin=35),
-  Label("62red",  ( 62,   0), FormFactor.ENDLESS,       ( 732,    0), ( 696,    0),  12 , feed_margin=35, color=Color.BLACK_RED_WHITE),
-  Label("102",    (102,   0), FormFactor.ENDLESS,       (1200,    0), (1164,    0),  12 , feed_margin=35, restricted_to_models=['QL-1050', 'QL-1060N', 'QL-1100', 'QL-1110NWB', 'QL-1115NWB']),
-  Label("103",    (104,   0), FormFactor.ENDLESS,       (1224,    0), (1200,    0),  12 , feed_margin=35, restricted_to_models=['QL-1100', 'QL-1110NWB']),
-  Label("104",    (104,   0), FormFactor.ENDLESS,       (1227,    0), (1200,    0),  -8 , feed_margin=35, restricted_to_models=['QL-1050', 'QL-1060N', 'QL-1100', 'QL-1110NWB', 'QL-1115NWB']),
-  Label("17x54",  ( 17,  54), FormFactor.DIE_CUT,       ( 201,  636), ( 165,  566),   0 ),
-  Label("17x87",  ( 17,  87), FormFactor.DIE_CUT,       ( 201, 1026), ( 165,  956),   0 ),
-  Label("23x23",  ( 23,  23), FormFactor.DIE_CUT,       ( 272,  272), ( 202,  202),  42 ),
-  Label("29x42",  ( 29,  42), FormFactor.DIE_CUT,       ( 342,  495), ( 306,  425),   6 ),
-  Label("29x90",  ( 29,  90), FormFactor.DIE_CUT,       ( 342, 1061), ( 306,  991),   6 ),
-  Label("39x90",  ( 38,  90), FormFactor.DIE_CUT,       ( 449, 1061), ( 413,  991),  12 ),
-  Label("39x48",  ( 39,  48), FormFactor.DIE_CUT,       ( 461,  565), ( 425,  495),   6 ),
-  Label("52x29",  ( 52,  29), FormFactor.DIE_CUT,       ( 614,  341), ( 578,  271),   0 ),
-  Label("54x29",  ( 54,  29), FormFactor.DIE_CUT,       ( 630,  341), ( 598,  271),  60 ),
-  Label("60x86",  ( 60,  87), FormFactor.DIE_CUT,       ( 708, 1024), ( 672,  954),  18 ),
-  Label("62x29",  ( 62,  29), FormFactor.DIE_CUT,       ( 732,  341), ( 696,  271),  12 ),
-  Label("62x100", ( 62, 100), FormFactor.DIE_CUT,       ( 732, 1179), ( 696, 1109),  12 ),
-  Label("102x51", (102,  51), FormFactor.DIE_CUT,       (1200,  596), (1164,  526),  12 , restricted_to_models=['QL-1050', 'QL-1060N', 'QL-1100', 'QL-1110NWB', 'QL-1115NWB']),
-  Label("102x152",(102, 153), FormFactor.DIE_CUT,       (1200, 1804), (1164, 1660),  12 , restricted_to_models=['QL-1050', 'QL-1060N', 'QL-1100', 'QL-1110NWB', 'QL-1115NWB']),
-  # size 103 has media width 104
-  Label("103x164",(104, 164), FormFactor.DIE_CUT,       (1224, 1941), (1200, 1822),  12 , restricted_to_models=['QL-1100', 'QL-1110NWB']),
-  Label("d12",    ( 12,  12), FormFactor.ROUND_DIE_CUT, ( 142,  142), (  94,   94), 113 , feed_margin=35),
-  Label("d24",    ( 24,  24), FormFactor.ROUND_DIE_CUT, ( 284,  284), ( 236,  236),  42 ),
-  Label("d58",    ( 58,  58), FormFactor.ROUND_DIE_CUT, ( 688,  688), ( 618,  618),  51 ),
-  Label("pt12",   ( 12,   0), FormFactor.PTOUCH_ENDLESS,( 128,    0), (  70,    0),  29, feed_margin=14),
-  Label("pt18",   ( 18,   0), FormFactor.PTOUCH_ENDLESS,( 128,    0), ( 112,    0),   8, feed_margin=14),
-  Label("pt24",   ( 24,   0), FormFactor.PTOUCH_ENDLESS,( 128,    0), ( 128,    0),   0, feed_margin=14),
-  Label("pt36",   ( 36,   0), FormFactor.PTOUCH_ENDLESS,( 512,    0), ( 454,    0),   61, feed_margin=14),
 
+ALL_LABELS = (
+    Label("12", (12, 0), FormFactor.ENDLESS, (142, 0), (106, 0), 29, feed_margin=35),
+    Label("12+17", (12, 0), FormFactor.ENDLESS, (342, 0), (306, 0), 29, feed_margin=35),
+    Label("18", (18, 0), FormFactor.ENDLESS, (256, 0), (234, 0), 171, feed_margin=14),
+    Label("29", (29, 0), FormFactor.ENDLESS, (342, 0), (306, 0), 6, feed_margin=35),
+    Label("38", (38, 0), FormFactor.ENDLESS, (449, 0), (413, 0), 12, feed_margin=35),
+    Label("50", (50, 0), FormFactor.ENDLESS, (590, 0), (554, 0), 12, feed_margin=35),
+    Label("54", (54, 0), FormFactor.ENDLESS, (636, 0), (590, 0), 0, feed_margin=35),
+    Label("62", (62, 0), FormFactor.ENDLESS, (732, 0), (696, 0), 12, feed_margin=35),
+    Label(
+        "62red",
+        (62, 0),
+        FormFactor.ENDLESS,
+        (732, 0),
+        (696, 0),
+        12,
+        feed_margin=35,
+        color=Color.BLACK_RED_WHITE,
+    ),
+    Label(
+        "102",
+        (102, 0),
+        FormFactor.ENDLESS,
+        (1200, 0),
+        (1164, 0),
+        12,
+        feed_margin=35,
+        restricted_to_models=[
+            "QL-1050",
+            "QL-1060N",
+            "QL-1100",
+            "QL-1110NWB",
+            "QL-1115NWB",
+        ],
+    ),
+    Label(
+        "103",
+        (104, 0),
+        FormFactor.ENDLESS,
+        (1224, 0),
+        (1200, 0),
+        12,
+        feed_margin=35,
+        restricted_to_models=["QL-1100", "QL-1110NWB"],
+    ),
+    Label(
+        "104",
+        (104, 0),
+        FormFactor.ENDLESS,
+        (1227, 0),
+        (1200, 0),
+        -8,
+        feed_margin=35,
+        restricted_to_models=[
+            "QL-1050",
+            "QL-1060N",
+            "QL-1100",
+            "QL-1110NWB",
+            "QL-1115NWB",
+        ],
+    ),
+    Label("17x54", (17, 54), FormFactor.DIE_CUT, (201, 636), (165, 566), 0),
+    Label("17x87", (17, 87), FormFactor.DIE_CUT, (201, 1026), (165, 956), 0),
+    Label("23x23", (23, 23), FormFactor.DIE_CUT, (272, 272), (202, 202), 42),
+    Label("29x42", (29, 42), FormFactor.DIE_CUT, (342, 495), (306, 425), 6),
+    Label("29x90", (29, 90), FormFactor.DIE_CUT, (342, 1061), (306, 991), 6),
+    Label("39x90", (38, 90), FormFactor.DIE_CUT, (449, 1061), (413, 991), 12),
+    Label("39x48", (39, 48), FormFactor.DIE_CUT, (461, 565), (425, 495), 6),
+    Label("52x29", (52, 29), FormFactor.DIE_CUT, (614, 341), (578, 271), 0),
+    Label("54x29", (54, 29), FormFactor.DIE_CUT, (630, 341), (598, 271), 60),
+    Label("60x86", (60, 87), FormFactor.DIE_CUT, (708, 1024), (672, 954), 18),
+    Label("62x29", (62, 29), FormFactor.DIE_CUT, (732, 341), (696, 271), 12),
+    Label("62x100", (62, 100), FormFactor.DIE_CUT, (732, 1179), (696, 1109), 12),
+    Label(
+        "102x51",
+        (102, 51),
+        FormFactor.DIE_CUT,
+        (1200, 596),
+        (1164, 526),
+        12,
+        restricted_to_models=[
+            "QL-1050",
+            "QL-1060N",
+            "QL-1100",
+            "QL-1110NWB",
+            "QL-1115NWB",
+        ],
+    ),
+    Label(
+        "102x152",
+        (102, 153),
+        FormFactor.DIE_CUT,
+        (1200, 1804),
+        (1164, 1660),
+        12,
+        restricted_to_models=[
+            "QL-1050",
+            "QL-1060N",
+            "QL-1100",
+            "QL-1110NWB",
+            "QL-1115NWB",
+        ],
+    ),
+    # size 103 has media width 104
+    Label(
+        "103x164",
+        (104, 164),
+        FormFactor.DIE_CUT,
+        (1224, 1941),
+        (1200, 1822),
+        12,
+        restricted_to_models=["QL-1100", "QL-1110NWB"],
+    ),
+    Label(
+        "d12",
+        (12, 12),
+        FormFactor.ROUND_DIE_CUT,
+        (142, 142),
+        (94, 94),
+        113,
+        feed_margin=35,
+    ),
+    Label("d24", (24, 24), FormFactor.ROUND_DIE_CUT, (284, 284), (236, 236), 42),
+    Label("d58", (58, 58), FormFactor.ROUND_DIE_CUT, (688, 688), (618, 618), 51),
+    Label(
+        "pt12",
+        (12, 0),
+        FormFactor.PTOUCH_ENDLESS,
+        (128, 0),
+        (70, 0),
+        29,
+        feed_margin=14,
+    ),
+    Label(
+        "pt18",
+        (18, 0),
+        FormFactor.PTOUCH_ENDLESS,
+        (128, 0),
+        (112, 0),
+        8,
+        feed_margin=14,
+    ),
+    Label(
+        "pt24",
+        (24, 0),
+        FormFactor.PTOUCH_ENDLESS,
+        (128, 0),
+        (128, 0),
+        0,
+        feed_margin=14,
+    ),
+    Label(
+        "pt36",
+        (36, 0),
+        FormFactor.PTOUCH_ENDLESS,
+        (512, 0),
+        (454, 0),
+        61,
+        feed_margin=14,
+    ),
 )
+
 
 class LabelsManager(ElementsManager):
     DEFAULT_ELEMENTS = copy.copy(ALL_LABELS)

--- a/brother_ql/models.py
+++ b/brother_ql/models.py
@@ -5,12 +5,14 @@ import copy
 
 from brother_ql.helpers import ElementsManager
 
+
 @attrs
 class Model(object):
     """
     This class represents a printer model. All specifics of a certain model
     and the opcodes it supports should be contained in this class.
     """
+
     #: A string identifier given to each model implemented. Eg. 'QL-500'.
     identifier = attrib(type=str)
     #: Minimum and maximum number of rows or 'dots' that can be printed.
@@ -42,31 +44,46 @@ class Model(object):
     def name(self):
         return self.identifier
 
+
 ALL_MODELS = [
-  Model('QL-500',   (295, 11811), compression=False, mode_setting=False, expanded_mode=False, cutting=False),
-  Model('QL-550',   (295, 11811), compression=False, mode_setting=False),
-  Model('QL-560',   (295, 11811), compression=False, mode_setting=False),
-  Model('QL-570',   (150, 11811), compression=False, mode_setting=False),
-  Model('QL-580N',  (150, 11811)),
-  Model('QL-600',   (150, 11811)),
-  Model('QL-650TD', (295, 11811)),
-  Model('QL-700',   (150, 11811), compression=False, mode_setting=False),
-  Model('QL-710W',  (150, 11811)),
-  Model('QL-720NW', (150, 11811)),
-  Model('QL-800',   (150, 11811), two_color=True, compression=False, num_invalidate_bytes=400),
-  Model('QL-810W',  (150, 11811), two_color=True, num_invalidate_bytes=400),
-  Model('QL-820NWB',(150, 11811), two_color=True, num_invalidate_bytes=400),
-  Model('QL-1050',  (295, 35433), number_bytes_per_row=162, additional_offset_r=44),
-  Model('QL-1060N', (295, 35433), number_bytes_per_row=162, additional_offset_r=44),
-  Model('QL-1100',  (301, 35434), number_bytes_per_row=162, additional_offset_r=44),
-  Model('QL-1110NWB',(301, 35434), number_bytes_per_row=162, additional_offset_r=44),
-  Model('QL-1115NWB',(301, 35434), number_bytes_per_row=162, additional_offset_r=44),
-  Model('PT-E550W',  (31, 14172), number_bytes_per_row=16),
-  Model('PT-P750W',  (31, 14172), number_bytes_per_row=16),
-  Model('PT-P900W',  (57, 28346), number_bytes_per_row=70),
-  Model('PT-P950NW',  (57, 28346), number_bytes_per_row=70),
+    Model(
+        "QL-500",
+        (295, 11811),
+        compression=False,
+        mode_setting=False,
+        expanded_mode=False,
+        cutting=False,
+    ),
+    Model("QL-550", (295, 11811), compression=False, mode_setting=False),
+    Model("QL-560", (295, 11811), compression=False, mode_setting=False),
+    Model("QL-570", (150, 11811), compression=False, mode_setting=False),
+    Model("QL-580N", (150, 11811)),
+    Model("QL-600", (150, 11811)),
+    Model("QL-650TD", (295, 11811)),
+    Model("QL-700", (150, 11811), compression=False, mode_setting=False),
+    Model("QL-710W", (150, 11811)),
+    Model("QL-720NW", (150, 11811)),
+    Model(
+        "QL-800",
+        (150, 11811),
+        two_color=True,
+        compression=False,
+        num_invalidate_bytes=400,
+    ),
+    Model("QL-810W", (150, 11811), two_color=True, num_invalidate_bytes=400),
+    Model("QL-820NWB", (150, 11811), two_color=True, num_invalidate_bytes=400),
+    Model("QL-1050", (295, 35433), number_bytes_per_row=162, additional_offset_r=44),
+    Model("QL-1060N", (295, 35433), number_bytes_per_row=162, additional_offset_r=44),
+    Model("QL-1100", (301, 35434), number_bytes_per_row=162, additional_offset_r=44),
+    Model("QL-1110NWB", (301, 35434), number_bytes_per_row=162, additional_offset_r=44),
+    Model("QL-1115NWB", (301, 35434), number_bytes_per_row=162, additional_offset_r=44),
+    Model("PT-E550W", (31, 14172), number_bytes_per_row=16),
+    Model("PT-P750W", (31, 14172), number_bytes_per_row=16),
+    Model("PT-P900W", (57, 28346), number_bytes_per_row=70),
+    Model("PT-P950NW", (57, 28346), number_bytes_per_row=70),
 ]
+
 
 class ModelsManager(ElementsManager):
     DEFAULT_ELEMENTS = copy.copy(ALL_MODELS)
-    ELEMENTS_NAME = 'model'
+    ELEMENTS_NAME = "model"

--- a/brother_ql/output_helpers.py
+++ b/brother_ql/output_helpers.py
@@ -5,33 +5,45 @@ from brother_ql.devicedependent import DIE_CUT_LABEL, ENDLESS_LABEL, ROUND_DIE_C
 
 logger = logging.getLogger(__name__)
 
+
 def textual_label_description(labels_to_include):
     output = "Supported label sizes:\n"
     output = ""
     fmt = " {label_size:9s} {dots_printable:14s} {label_descr:26s}\n"
-    output += fmt.format(label_size="Name", dots_printable="Printable px", label_descr="Description")
-    #output += fmt.format(label_size="", dots_printable="width x height", label_descr="")
+    output += fmt.format(
+        label_size="Name", dots_printable="Printable px", label_descr="Description"
+    )
+    # output += fmt.format(label_size="", dots_printable="width x height", label_descr="")
     for label_size in labels_to_include:
         s = label_type_specs[label_size]
-        if s['kind'] in (DIE_CUT_LABEL, ROUND_DIE_CUT_LABEL):
+        if s["kind"] in (DIE_CUT_LABEL, ROUND_DIE_CUT_LABEL):
             dp_fmt = "{0:4d} x {1:4d}"
-        elif s['kind'] == ENDLESS_LABEL:
+        elif s["kind"] == ENDLESS_LABEL:
             dp_fmt = "{0:4d}"
         else:
             dp_fmt = " - unknown - "
-        dots_printable = dp_fmt.format(*s['dots_printable'])
-        label_descr = s['name']
-        output += fmt.format(label_size=label_size, dots_printable=dots_printable, label_descr=label_descr)
+        dots_printable = dp_fmt.format(*s["dots_printable"])
+        label_descr = s["name"]
+        output += fmt.format(
+            label_size=label_size,
+            dots_printable=dots_printable,
+            label_descr=label_descr,
+        )
     return output
+
 
 def log_discovered_devices(available_devices, level=logging.INFO):
     for ad in available_devices:
-        result = {'model': 'unknown'}
+        result = {"model": "unknown"}
         result.update(ad)
-        logger.log(level, "  Found a label printer: {identifier}  (model: {model})".format(**result))
+        logger.log(
+            level,
+            "  Found a label printer: {identifier}  (model: {model})".format(**result),
+        )
+
 
 def textual_description_discovered_devices(available_devices):
     output = ""
     for ad in available_devices:
-        output += ad['identifier']
+        output += ad["identifier"]
     return output

--- a/brother_ql/raster.py
+++ b/brother_ql/raster.py
@@ -12,13 +12,10 @@ import logging
 
 import packbits
 from PIL import Image
-import io
 
 from brother_ql.models import ModelsManager
 from .devicedependent import (
     models,
-    min_max_feed,
-    min_max_length_dots,
     number_bytes_per_row,
     compressionsupport,
     cuttingsupport,
@@ -28,7 +25,6 @@ from .devicedependent import (
 )
 
 from . import (
-    BrotherQLError,
     BrotherQLUnsupportedCmd,
     BrotherQLUnknownModel,
     BrotherQLRasterError,

--- a/brother_ql/raster.py
+++ b/brother_ql/raster.py
@@ -15,23 +15,30 @@ from PIL import Image
 import io
 
 from brother_ql.models import ModelsManager
-from .devicedependent import models, \
-                             min_max_feed, \
-                             min_max_length_dots, \
-                             number_bytes_per_row, \
-                             compressionsupport, \
-                             cuttingsupport, \
-                             expandedmode, \
-                             two_color_support, \
-                             modesetting
+from .devicedependent import (
+    models,
+    min_max_feed,
+    min_max_length_dots,
+    number_bytes_per_row,
+    compressionsupport,
+    cuttingsupport,
+    expandedmode,
+    two_color_support,
+    modesetting,
+)
 
-from . import BrotherQLError, BrotherQLUnsupportedCmd, BrotherQLUnknownModel, BrotherQLRasterError
+from . import (
+    BrotherQLError,
+    BrotherQLUnsupportedCmd,
+    BrotherQLUnknownModel,
+    BrotherQLRasterError,
+)
 from io import BytesIO
 
 logger = logging.getLogger(__name__)
 
-class BrotherQLRaster(object):
 
+class BrotherQLRaster(object):
     """
     This class facilitates the creation of a complete set
     of raster instructions by adding them one after the other
@@ -47,11 +54,11 @@ class BrotherQLRaster(object):
     :ivar bool exception_on_warning: If set to True, an exception is raised if trying to add instruction which are not supported on the selected model. If set to False, the instruction is simply ignored and a warning sent to logging/stderr.
     """
 
-    def __init__(self, model='QL-500'):
+    def __init__(self, model="QL-500"):
         if model not in models:
             raise BrotherQLUnknownModel()
         self.model = model
-        self.data = b''
+        self.data = b""
         self._pquality = True
         self.page_number = 0
         self.cut_at_end = True
@@ -98,11 +105,11 @@ class BrotherQLRaster(object):
 
     def add_initialize(self):
         self.page_number = 0
-        self.data += b'\x1B\x40' # ESC @
+        self.data += b"\x1b\x40"  # ESC @
 
     def add_status_information(self):
-        """ Status Information Request """
-        self.data += b'\x1B\x69\x53' # ESC i S
+        """Status Information Request"""
+        self.data += b"\x1b\x69\x53"  # ESC i S
 
     def add_switch_mode(self):
         """
@@ -111,25 +118,31 @@ class BrotherQLRaster(object):
         the mode change (others are in raster mode already).
         """
         if self.model not in modesetting:
-            self._unsupported("Trying to switch the operating mode on a printer that doesn't support the command.")
+            self._unsupported(
+                "Trying to switch the operating mode on a printer that doesn't support the command."
+            )
             return
-        self.data += b'\x1B\x69\x61\x01' # ESC i a
+        self.data += b"\x1b\x69\x61\x01"  # ESC i a
 
     def add_invalidate(self):
-        """ clear command buffer """
-        self.data += b'\x00' * self.num_invalidate_bytes
+        """clear command buffer"""
+        self.data += b"\x00" * self.num_invalidate_bytes
 
     @property
-    def mtype(self): return self._mtype
+    def mtype(self):
+        return self._mtype
 
     @property
-    def mwidth(self): return self._mwidth
+    def mwidth(self):
+        return self._mwidth
 
     @property
-    def mlength(self): return self._mlength
+    def mlength(self):
+        return self._mlength
 
     @property
-    def pquality(self): return self._pquality
+    def pquality(self):
+        return self._pquality
 
     @mtype.setter
     def mtype(self, value):
@@ -148,7 +161,7 @@ class BrotherQLRaster(object):
         self._pquality = bool(value)
 
     def add_media_and_quality(self, rnumber):
-        self.data += b'\x1B\x69\x7A' # ESC i z
+        self.data += b"\x1b\x69\x7a"  # ESC i z
         valid_flags = 0x80
         valid_flags |= (self._mtype is not None) << 1
         valid_flags |= (self._mwidth is not None) << 2
@@ -156,41 +169,49 @@ class BrotherQLRaster(object):
         valid_flags |= self._pquality << 6
         self.data += bytes([valid_flags])
         vals = [self._mtype, self._mwidth, self._mlength]
-        self.data += b''.join(b'\x00' if val is None else val for val in vals)
-        self.data += struct.pack('<L', rnumber)
+        self.data += b"".join(b"\x00" if val is None else val for val in vals)
+        self.data += struct.pack("<L", rnumber)
         self.data += bytes([0 if self.page_number == 0 else 1])
-        self.data += b'\x00'
+        self.data += b"\x00"
         # INFO:  media/quality (1B 69 7A) --> found! (payload: 8E 0A 3E 00 D2 00 00 00 00 00)
 
-    def add_autocut(self, autocut = False):
+    def add_autocut(self, autocut=False):
         if self.model not in cuttingsupport:
-            self._unsupported("Trying to call add_autocut with a printer that doesn't support it")
+            self._unsupported(
+                "Trying to call add_autocut with a printer that doesn't support it"
+            )
             return
-        self.data += b'\x1B\x69\x4D' # ESC i M
-        if self.model.startswith('PT'):
+        self.data += b"\x1b\x69\x4d"  # ESC i M
+        if self.model.startswith("PT"):
             self.data += bytes([autocut << 5])
         else:
             self.data += bytes([autocut << 6])
 
     def add_cut_every(self, n=1):
         if self.model not in cuttingsupport:
-            self._unsupported("Trying to call add_cut_every with a printer that doesn't support it")
+            self._unsupported(
+                "Trying to call add_cut_every with a printer that doesn't support it"
+            )
             return
-        if self.model.startswith('PT'):
+        if self.model.startswith("PT"):
             return
-        self.data += b'\x1B\x69\x41' # ESC i A
+        self.data += b"\x1b\x69\x41"  # ESC i A
         self.data += bytes([n & 0xFF])
 
     def add_expanded_mode(self):
         if self.model not in expandedmode:
-            self._unsupported("Trying to set expanded mode (dpi/cutting at end) on a printer that doesn't support it")
+            self._unsupported(
+                "Trying to set expanded mode (dpi/cutting at end) on a printer that doesn't support it"
+            )
             return
         if self.two_color_printing and not self.two_color_support:
-            self._unsupported("Trying to set two_color_printing in expanded mode on a printer that doesn't support it.")
+            self._unsupported(
+                "Trying to set two_color_printing in expanded mode on a printer that doesn't support it."
+            )
             return
-        self.data += b'\x1B\x69\x4B' # ESC i K
+        self.data += b"\x1b\x69\x4b"  # ESC i K
         flags = 0x00
-        if self.model.startswith('PT'):
+        if self.model.startswith("PT"):
             flags |= self.half_cut << 2
             flags |= self.no_chain_printing << 3
             flags |= self.dpi_600 << 5
@@ -201,8 +222,8 @@ class BrotherQLRaster(object):
         self.data += bytes([flags])
 
     def add_margins(self, dots=0x23):
-        self.data += b'\x1B\x69\x64' # ESC i d
-        self.data += struct.pack('<H', dots)
+        self.data += b"\x1b\x69\x64"  # ESC i d
+        self.data += struct.pack("<H", dots)
 
     def add_compression(self, compression=True):
         """
@@ -214,18 +235,20 @@ class BrotherQLRaster(object):
         :param bool compression: Whether compression should be on or off
         """
         if self.model not in compressionsupport:
-            self._unsupported("Trying to set compression on a printer that doesn't support it")
+            self._unsupported(
+                "Trying to set compression on a printer that doesn't support it"
+            )
             return
         self._compression = compression
-        self.data += b'\x4D' # M
+        self.data += b"\x4d"  # M
         self.data += bytes([compression << 1])
 
     def get_pixel_width(self):
         try:
             nbpr = number_bytes_per_row[self.model]
         except:
-            nbpr = number_bytes_per_row['default']
-        return nbpr*8
+            nbpr = number_bytes_per_row["default"]
+        return nbpr * 8
 
     def add_raster_data(self, image, second_image=None):
         """
@@ -238,8 +261,10 @@ class BrotherQLRaster(object):
         """
         logger.debug("raster_image_size: {0}x{1}".format(*image.size))
         if image.size[0] != self.get_pixel_width():
-            fmt = 'Wrong pixel width: {}, expected {}'
-            raise BrotherQLRasterError(fmt.format(image.size[0], self.get_pixel_width()))
+            fmt = "Wrong pixel width: {}, expected {}"
+            raise BrotherQLRasterError(
+                fmt.format(image.size[0], self.get_pixel_width())
+            )
         images = [image]
         if second_image:
             if image.size != second_image.size:
@@ -250,25 +275,25 @@ class BrotherQLRaster(object):
         for image in images:
             image = image.transpose(Image.FLIP_LEFT_RIGHT)
             image = image.convert("1")
-            frames.append(bytes(image.tobytes(encoder_name='raw')))
+            frames.append(bytes(image.tobytes(encoder_name="raw")))
         frame_len = len(frames[0])
-        row_len = images[0].size[0]//8
+        row_len = images[0].size[0] // 8
         start = 0
         file_str = BytesIO()
         while start + row_len <= frame_len:
             for i, frame in enumerate(frames):
-                row = frame[start:start+row_len]
+                row = frame[start : start + row_len]
                 if self._compression:
                     row = packbits.encode(row)
-                translen = len(row) # number of bytes to be transmitted
-                if self.model.startswith('PT'):
-                    file_str.write(b'\x47')
-                    file_str.write(bytes([translen%256, translen//256]))
+                translen = len(row)  # number of bytes to be transmitted
+                if self.model.startswith("PT"):
+                    file_str.write(b"\x47")
+                    file_str.write(bytes([translen % 256, translen // 256]))
                 else:
                     if second_image:
-                        file_str.write(b'\x77\x01' if i == 0 else b'\x77\x02')
+                        file_str.write(b"\x77\x01" if i == 0 else b"\x77\x02")
                     else:
-                        file_str.write(b'\x67\x00')
+                        file_str.write(b"\x67\x00")
                     file_str.write(bytes([translen]))
                 file_str.write(row)
             start += row_len
@@ -276,6 +301,6 @@ class BrotherQLRaster(object):
 
     def add_print(self, last_page=True):
         if last_page:
-            self.data += b'\x1A' # 0x1A = ^Z = SUB; here: EOF = End of File
+            self.data += b"\x1a"  # 0x1A = ^Z = SUB; here: EOF = End of File
         else:
-            self.data += b'\x0C' # 0x0C = FF  = Form Feed
+            self.data += b"\x0c"  # 0x0C = FF  = Form Feed

--- a/brother_ql/reader.py
+++ b/brother_ql/reader.py
@@ -3,7 +3,6 @@
 import struct
 import io
 import logging
-import sys
 
 from PIL import Image
 from PIL.ImageOps import colorize

--- a/brother_ql/reader.py
+++ b/brother_ql/reader.py
@@ -12,112 +12,126 @@ logger = logging.getLogger(__name__)
 
 OPCODES = {
     # signature              name    following bytes   description
-    b'\x00':                 ("preamble",       -1, "Preamble, 200-300x 0x00 to clear comamnd buffer"),
-    b'\x4D':                 ("compression",     1, ""),
-    b'\x67':                 ("raster QL",         -1, ""),
-    b'\x47':                 ("raster P-touch",    -1, ""),
-    b'\x77':                 ("2-color raster QL", -1, ""),
-    b'\x5a':                 ("zero raster",     0, "empty raster line"),
-    b'\x0C':                 ("print",           0, "print intermediate page"),
-    b'\x1A':                 ("print",           0, "print final page"),
-    b'\x1b\x40':             ("init",            0, "initialization"),
-    b'\x1b\x69\x61':         ("mode setting",    1, ""),
-    b'\x1b\x69\x21':         ("automatic status",1, ""),
-    b'\x1b\x69\x7A':         ("media/quality",  10, "print-media and print-quality"),
-    b'\x1b\x69\x4D':         ("various",         1, "Auto cut flag in bit 7"),
-    b'\x1b\x69\x41':         ("cut-every",       1, "cut every n-th page"),
-    b'\x1b\x69\x4B':         ("expanded",        1, ""),
-    b'\x1b\x69\x64':         ("margins",         2, ""),
-    b'\x1b\x69\x55\x77\x01': ('amedia',        127, "Additional media information command"),
-    b'\x1b\x69\x55\x4A':     ('jobid',          14, "Job ID setting command"),
-    b'\x1b\x69\x58\x47':     ("request_config",  0, "Request transmission of .ini config file of printer"),
-    b'\x1b\x69\x6B\x63':     ("number_of_copies",  2, "Internal specification commands"),
-    b'\x1b\x69\x53':         ('status request',  0, "A status information request sent to the printer"),
-    b'\x80\x20\x42':         ('status response',29, "A status response received from the printer"),
+    b"\x00": ("preamble", -1, "Preamble, 200-300x 0x00 to clear comamnd buffer"),
+    b"\x4d": ("compression", 1, ""),
+    b"\x67": ("raster QL", -1, ""),
+    b"\x47": ("raster P-touch", -1, ""),
+    b"\x77": ("2-color raster QL", -1, ""),
+    b"\x5a": ("zero raster", 0, "empty raster line"),
+    b"\x0c": ("print", 0, "print intermediate page"),
+    b"\x1a": ("print", 0, "print final page"),
+    b"\x1b\x40": ("init", 0, "initialization"),
+    b"\x1b\x69\x61": ("mode setting", 1, ""),
+    b"\x1b\x69\x21": ("automatic status", 1, ""),
+    b"\x1b\x69\x7a": ("media/quality", 10, "print-media and print-quality"),
+    b"\x1b\x69\x4d": ("various", 1, "Auto cut flag in bit 7"),
+    b"\x1b\x69\x41": ("cut-every", 1, "cut every n-th page"),
+    b"\x1b\x69\x4b": ("expanded", 1, ""),
+    b"\x1b\x69\x64": ("margins", 2, ""),
+    b"\x1b\x69\x55\x77\x01": ("amedia", 127, "Additional media information command"),
+    b"\x1b\x69\x55\x4a": ("jobid", 14, "Job ID setting command"),
+    b"\x1b\x69\x58\x47": (
+        "request_config",
+        0,
+        "Request transmission of .ini config file of printer",
+    ),
+    b"\x1b\x69\x6b\x63": ("number_of_copies", 2, "Internal specification commands"),
+    b"\x1b\x69\x53": (
+        "status request",
+        0,
+        "A status information request sent to the printer",
+    ),
+    b"\x80\x20\x42": (
+        "status response",
+        29,
+        "A status response received from the printer",
+    ),
 }
 
 dot_widths = {
-  62: 90*8,
+    62: 90 * 8,
 }
 
 RESP_ERROR_INFORMATION_1_DEF = {
-  0: 'No media when printing',
-  1: 'End of media (die-cut size only)',
-  2: 'Tape cutter jam',
-  3: 'Weak batteries',
-  4: 'Main unit in use (QL-560/650TD/1050)',
-  5: 'Printer turned off',
-  6: 'High-voltage adapter (not used)',
-  7: 'Fan doesn\'t work (QL-1050/1060N)',
+    0: "No media when printing",
+    1: "End of media (die-cut size only)",
+    2: "Tape cutter jam",
+    3: "Weak batteries",
+    4: "Main unit in use (QL-560/650TD/1050)",
+    5: "Printer turned off",
+    6: "High-voltage adapter (not used)",
+    7: "Fan doesn't work (QL-1050/1060N)",
 }
 
 RESP_ERROR_INFORMATION_2_DEF = {
-  0: 'Replace media error',
-  1: 'Expansion buffer full error',
-  2: 'Transmission / Communication error',
-  3: 'Communication buffer full error (not used)',
-  4: 'Cover opened while printing (Except QL-500)',
-  5: 'Cancel key (not used) or Overheating error (PT-E550W/P750W/P710BT)',
-  6: 'Media cannot be fed (also when the media end is detected)',
-  7: 'System error',
+    0: "Replace media error",
+    1: "Expansion buffer full error",
+    2: "Transmission / Communication error",
+    3: "Communication buffer full error (not used)",
+    4: "Cover opened while printing (Except QL-500)",
+    5: "Cancel key (not used) or Overheating error (PT-E550W/P750W/P710BT)",
+    6: "Media cannot be fed (also when the media end is detected)",
+    7: "System error",
 }
 
 RESP_MEDIA_TYPES = {
-  0x00: 'No media',
-  0x01: 'Laminated tape',
-  0x03: 'Non-laminated type',
-  0x11: 'Heat-Shrink Tube',
-  0x0A: 'Continuous length tape',
-  0x0B: 'Die-cut labels',
+    0x00: "No media",
+    0x01: "Laminated tape",
+    0x03: "Non-laminated type",
+    0x11: "Heat-Shrink Tube",
+    0x0A: "Continuous length tape",
+    0x0B: "Die-cut labels",
 }
 
 RESP_STATUS_TYPES = {
-  0x00: 'Reply to status request',
-  0x01: 'Printing completed',
-  0x02: 'Error occurred',
-  0x03: 'Exit IF mode',
-  0x04: 'Turned off',
-  0x05: 'Notification',
-  0x06: 'Phase change',
+    0x00: "Reply to status request",
+    0x01: "Printing completed",
+    0x02: "Error occurred",
+    0x03: "Exit IF mode",
+    0x04: "Turned off",
+    0x05: "Notification",
+    0x06: "Phase change",
 }
 
 RESP_PHASE_TYPES = {
-  0x00: 'Waiting to receive',
-  0x01: 'Printing state',
+    0x00: "Waiting to receive",
+    0x01: "Printing state",
 }
 
 RESP_BYTE_NAMES = [
-  'Print head mark',
-  'Size',
-  'Fixed (B=0x42)',
-  'Device dependent',
-  'Device dependent',
-  'Fixed (0=0x30)',
-  'Fixed (0x00 or 0=0x30)',
-  'Fixed (0x00)',
-  'Error information 1',
-  'Error information 2',
-  'Media width',
-  'Media type',
-  'Fixed (0x00)',
-  'Fixed (0x00)',
-  'Reserved',
-  'Mode',
-  'Fixed (0x00)',
-  'Media length',
-  'Status type',
-  'Phase type',
-  'Phase number (high)',
-  'Phase number (low)',
-  'Notification number',
-  'Expansion area',
-  'Tape color information',
-  'Text color information',
-  'Hardware settings',
+    "Print head mark",
+    "Size",
+    "Fixed (B=0x42)",
+    "Device dependent",
+    "Device dependent",
+    "Fixed (0=0x30)",
+    "Fixed (0x00 or 0=0x30)",
+    "Fixed (0x00)",
+    "Error information 1",
+    "Error information 2",
+    "Media width",
+    "Media type",
+    "Fixed (0x00)",
+    "Fixed (0x00)",
+    "Reserved",
+    "Mode",
+    "Fixed (0x00)",
+    "Media length",
+    "Status type",
+    "Phase type",
+    "Phase number (high)",
+    "Phase number (low)",
+    "Notification number",
+    "Expansion area",
+    "Tape color information",
+    "Text color information",
+    "Hardware settings",
 ]
 
+
 def hex_format(data):
-    return ' '.join('{:02X}'.format(byte) for byte in data)
+    return " ".join("{:02X}".format(byte) for byte in data)
+
 
 def chunker(data, raise_exception=False):
     """
@@ -130,11 +144,12 @@ def chunker(data, raise_exception=False):
     instructions = []
     data = bytes(data)
     while True:
-        if len(data) == 0: break
+        if len(data) == 0:
+            break
         try:
             opcode = match_opcode(data)
         except:
-            msg = 'unknown opcode starting with {}...)'.format(hex_format(data[0:4]))
+            msg = "unknown opcode starting with {}...)".format(hex_format(data[0:4]))
             if raise_exception:
                 raise ValueError(msg)
             else:
@@ -143,43 +158,49 @@ def chunker(data, raise_exception=False):
                 continue
         opcode_def = OPCODES[opcode]
         num_bytes = len(opcode)
-        if opcode_def[1] > 0: num_bytes += opcode_def[1]
-        elif opcode_def[0] in ('raster QL', '2-color raster QL'):
+        if opcode_def[1] > 0:
+            num_bytes += opcode_def[1]
+        elif opcode_def[0] in ("raster QL", "2-color raster QL"):
             num_bytes += data[2] + 2
-        elif opcode_def[0] in ('raster P-touch',):
-            num_bytes += data[1] + data[2]*256 + 2
-        #payload = data[len(opcode):num_bytes]
+        elif opcode_def[0] in ("raster P-touch",):
+            num_bytes += data[1] + data[2] * 256 + 2
+        # payload = data[len(opcode):num_bytes]
         instructions.append(data[:num_bytes])
         yield instructions[-1]
         data = data[num_bytes:]
-    #return instructions
+    # return instructions
+
 
 def match_opcode(data):
     matching_opcodes = [opcode for opcode in OPCODES.keys() if data.startswith(opcode)]
     assert len(matching_opcodes) == 1
     return matching_opcodes[0]
 
+
 def interpret_response(data):
     data = bytes(data)
     if len(data) < 32:
-        raise NameError('Insufficient amount of data received', hex_format(data))
-    if not data.startswith(b'\x80\x20\x42'):
-        raise NameError("Printer response doesn't start with the usual header (80:20:42)", hex_format(data))
+        raise NameError("Insufficient amount of data received", hex_format(data))
+    if not data.startswith(b"\x80\x20\x42"):
+        raise NameError(
+            "Printer response doesn't start with the usual header (80:20:42)",
+            hex_format(data),
+        )
     for i, byte_name in enumerate(RESP_BYTE_NAMES):
-        logger.debug('Byte %2d %24s %02X', i, byte_name+':', data[i])
+        logger.debug("Byte %2d %24s %02X", i, byte_name + ":", data[i])
     errors = []
     error_info_1 = data[8]
     error_info_2 = data[9]
     for error_bit in RESP_ERROR_INFORMATION_1_DEF:
         if error_info_1 & (1 << error_bit):
-            logger.error('Error: ' + RESP_ERROR_INFORMATION_1_DEF[error_bit])
+            logger.error("Error: " + RESP_ERROR_INFORMATION_1_DEF[error_bit])
             errors.append(RESP_ERROR_INFORMATION_1_DEF[error_bit])
     for error_bit in RESP_ERROR_INFORMATION_2_DEF:
         if error_info_2 & (1 << error_bit):
-            logger.error('Error: ' + RESP_ERROR_INFORMATION_2_DEF[error_bit])
+            logger.error("Error: " + RESP_ERROR_INFORMATION_2_DEF[error_bit])
             errors.append(RESP_ERROR_INFORMATION_2_DEF[error_bit])
 
-    media_width  = data[10]
+    media_width = data[10]
     media_length = data[17]
 
     media_type = data[11]
@@ -204,12 +225,12 @@ def interpret_response(data):
         logger.error("Unknown phase type %02X", phase_type)
 
     response = {
-      'status_type': status_type,
-      'phase_type': phase_type,
-      'media_type': media_type,
-      'media_width': media_width,
-      'media_length': media_length,
-      'errors': errors,
+        "status_type": status_type,
+        "phase_type": phase_type,
+        "media_type": media_type,
+        "media_width": media_width,
+        "media_length": media_length,
+        "errors": errors,
     }
     return response
 
@@ -221,12 +242,16 @@ def merge_specific_instructions(chunks, join_preamble=True, join_raster=True):
     """
     new_instructions = []
     last_opcode = None
-    instruction_buffer = b''
+    instruction_buffer = b""
     for instruction in chunks:
         opcode = match_opcode(instruction)
-        if   join_preamble and OPCODES[opcode][0] == 'preamble' and last_opcode == 'preamble':
+        if (
+            join_preamble
+            and OPCODES[opcode][0] == "preamble"
+            and last_opcode == "preamble"
+        ):
             instruction_buffer += instruction
-        elif join_raster   and 'raster' in OPCODES[opcode][0] and 'raster' in last_opcode:
+        elif join_raster and "raster" in OPCODES[opcode][0] and "raster" in last_opcode:
             instruction_buffer += instruction
         else:
             if instruction_buffer:
@@ -237,12 +262,13 @@ def merge_specific_instructions(chunks, join_preamble=True, join_raster=True):
         new_instructions.append(instruction_buffer)
     return new_instructions
 
+
 class BrotherQLReader(object):
-    DEFAULT_FILENAME_FMT = 'label{counter:04d}.png'
+    DEFAULT_FILENAME_FMT = "label{counter:04d}.png"
 
     def __init__(self, brother_file):
         if type(brother_file) in (str,):
-            brother_file = io.open(brother_file, 'rb')
+            brother_file = io.open(brother_file, "rb")
         self.brother_file = brother_file
         self.mwidth, self.mheight = None, None
         self.raster_no = None
@@ -261,21 +287,29 @@ class BrotherQLReader(object):
             for opcode in OPCODES.keys():
                 if instruction.startswith(opcode):
                     opcode_def = OPCODES[opcode]
-                    if opcode_def[0] == 'init':
+                    if opcode_def[0] == "init":
                         self.mwidth, self.mheight = None, None
                         self.raster_no = None
                         self.black_rows = []
                         self.red_rows = []
-                    payload = instruction[len(opcode):]
-                    logger.info(" {} ({}) --> found! (payload: {})".format(opcode_def[0], hex_format(opcode), hex_format(payload)))
-                    if opcode_def[0] == 'compression':
+                    payload = instruction[len(opcode) :]
+                    logger.info(
+                        " {} ({}) --> found! (payload: {})".format(
+                            opcode_def[0], hex_format(opcode), hex_format(payload)
+                        )
+                    )
+                    if opcode_def[0] == "compression":
                         self.compression = payload[0] == 0x02
-                    if opcode_def[0] == 'zero raster':
+                    if opcode_def[0] == "zero raster":
                         self.black_rows.append(bytes())
                         if self.two_color_printing:
                             self.red_rows.append(bytes())
-                    if opcode_def[0] in ('raster QL', '2-color raster QL', 'raster P-touch'):
-                        rpl = bytes(payload[2:]) # raster payload
+                    if opcode_def[0] in (
+                        "raster QL",
+                        "2-color raster QL",
+                        "raster P-touch",
+                    ):
+                        rpl = bytes(payload[2:])  # raster payload
                         if self.compression:
                             row = bytes()
                             index = 0
@@ -285,57 +319,66 @@ class BrotherQLReader(object):
                                     num = num - 0x100
                                 if num < 0:
                                     num = -num + 1
-                                    row += bytes([rpl[index+1]] * num)
+                                    row += bytes([rpl[index + 1]] * num)
                                     index += 2
                                 else:
                                     num = num + 1
-                                    row += rpl[index+1:index+1+num]
+                                    row += rpl[index + 1 : index + 1 + num]
                                     index += 1 + num
-                                if index >= len(rpl): break
+                                if index >= len(rpl):
+                                    break
                         else:
                             row = rpl
-                        if opcode_def[0] in ('raster QL', 'raster P-touch'):
+                        if opcode_def[0] in ("raster QL", "raster P-touch"):
                             self.black_rows.append(row)
-                        else: # 2-color
-                            if   payload[0] == 0x01:
+                        else:  # 2-color
+                            if payload[0] == 0x01:
                                 self.black_rows.append(row)
                             elif payload[0] == 0x02:
                                 self.red_rows.append(row)
                             else:
                                 raise NotImplementedError("color: 0x%x" % payload[0])
-                    if opcode_def[0] == 'expanded':
+                    if opcode_def[0] == "expanded":
                         self.two_color_printing = bool(payload[0] & (1 << 0))
                         self.cut_at_end = bool(payload[0] & (1 << 3))
                         self.high_resolution_printing = bool(payload[0] & (1 << 6))
-                    if opcode_def[0] == 'media/quality':
-                        self.raster_no = struct.unpack('<L', payload[4:8])[0]
+                    if opcode_def[0] == "media/quality":
+                        self.raster_no = struct.unpack("<L", payload[4:8])[0]
                         self.mwidth = instruction[len(opcode) + 2]
-                        self.mlength = instruction[len(opcode) + 3]*256
+                        self.mlength = instruction[len(opcode) + 3] * 256
                         fmt = " media width: {} mm, media length: {} mm, raster no: {} rows"
-                        logger.info(fmt.format(self.mwidth, self.mlength, self.raster_no))
-                    if opcode_def[0] == 'print':
+                        logger.info(
+                            fmt.format(self.mwidth, self.mlength, self.raster_no)
+                        )
+                    if opcode_def[0] == "print":
                         logger.info("Len of black rows: %d", len(self.black_rows))
                         logger.info("Len of red   rows: %d", len(self.red_rows))
+
                         def get_im(rows):
-                            if not len(rows): return None
-                            width_dots  = max(len(row) for row in rows)
+                            if not len(rows):
+                                return None
+                            width_dots = max(len(row) for row in rows)
                             height_dots = len(rows)
-                            size = (width_dots*8, height_dots)
+                            size = (width_dots * 8, height_dots)
                             expanded_rows = []
                             for row in rows:
                                 if len(row) == 0:
-                                    expanded_rows.append(b'\x00'*width_dots)
+                                    expanded_rows.append(b"\x00" * width_dots)
                                 else:
                                     expanded_rows.append(row)
-                            data = bytes(b''.join(expanded_rows))
-                            data = bytes([2**8 + ~byte for byte in data]) # invert b/w
-                            im = Image.frombytes("1", size, data, decoder_name='raw')
+                            data = bytes(b"".join(expanded_rows))
+                            data = bytes([2**8 + ~byte for byte in data])  # invert b/w
+                            im = Image.frombytes("1", size, data, decoder_name="raw")
                             return im
+
                         if not self.two_color_printing:
                             im_black = get_im(self.black_rows)
                             im = im_black
                         else:
-                            im_black, im_red = (get_im(rows) for rows in (self.black_rows, self.red_rows))
+                            im_black, im_red = (
+                                get_im(rows)
+                                for rows in (self.black_rows, self.red_rows)
+                            )
                             im_black = im_black.convert("RGBA")
                             im_red = im_red.convert("L")
                             im_red = colorize(im_red, (255, 0, 0), (255, 255, 255))
@@ -352,5 +395,5 @@ class BrotherQLReader(object):
                         im = im.transpose(Image.FLIP_LEFT_RIGHT)
                         img_name = self.filename_fmt.format(counter=self.page_counter)
                         im.save(img_name)
-                        print('Page saved as {}'.format(img_name))
+                        print("Page saved as {}".format(img_name))
                         self.page_counter += 1

--- a/setup.py
+++ b/setup.py
@@ -7,60 +7,58 @@ except ImportError:
 
 try:
     import pypandoc
-    LDESC = open('README.md', 'r').read()
-    LDESC = pypandoc.convert(LDESC, 'rst', format='md')
+
+    LDESC = open("README.md", "r").read()
+    LDESC = pypandoc.convert(LDESC, "rst", format="md")
 except (ImportError, IOError, RuntimeError) as e:
     print("Could not create long description:")
     print(str(e))
-    LDESC = ''
+    LDESC = ""
 
-setup(name='brother_ql',
-      version = '0.9.dev0',
-      description = 'Python package to talk to Brother QL label printers',
-      long_description = LDESC,
-      author = 'Philipp Klaus',
-      author_email = 'philipp.l.klaus@web.de',
-      url = 'https://github.com/matmair/brother_ql-inventree',
-      license = 'GPL',
-      packages = ['brother_ql',
-                  'brother_ql.backends'],
-      entry_points = {
-          'console_scripts': [
-              'brother_ql = brother_ql.cli:cli',
-              'brother_ql_analyse = brother_ql.brother_ql_analyse:main',
-              'brother_ql_create  = brother_ql.brother_ql_create:main',
-              'brother_ql_print   = brother_ql.brother_ql_print:main',
-              'brother_ql_debug   = brother_ql.brother_ql_debug:main',
-              'brother_ql_info    = brother_ql.brother_ql_info:main',
-          ],
-      },
-      include_package_data = False,
-      zip_safe = True,
-      platforms = 'any',
-      install_requires = [
-          "click",
-          "packbits",
-          "pillow>=10.0.0",
-          "pyusb",
-          'attrs',
-          'typing;python_version<"3.5"',
-          'enum34;python_version<"3.4"',
-      ],
-      extras_require = {
-          #'brother_ql_analyse':  ["matplotlib",],
-          #'brother_ql_create' :  ["matplotlib",],
-      },
-      keywords = 'Brother QL-500 QL-550 QL-560 QL-570 QL-700 QL-710W QL-720NW QL-800 QL-810W QL-820NWB QL-1050 QL-1060N',
-      classifiers = [
-          'Development Status :: 4 - Beta',
-          'Operating System :: OS Independent',
-          'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 3',
-          'Topic :: Scientific/Engineering :: Visualization',
-          'Topic :: System :: Hardware :: Hardware Drivers',
-      ]
+setup(
+    name="brother_ql",
+    version="0.9.dev0",
+    description="Python package to talk to Brother QL label printers",
+    long_description=LDESC,
+    author="Philipp Klaus",
+    author_email="philipp.l.klaus@web.de",
+    url="https://github.com/matmair/brother_ql-inventree",
+    license="GPL",
+    packages=["brother_ql", "brother_ql.backends"],
+    entry_points={
+        "console_scripts": [
+            "brother_ql = brother_ql.cli:cli",
+            "brother_ql_analyse = brother_ql.brother_ql_analyse:main",
+            "brother_ql_create  = brother_ql.brother_ql_create:main",
+            "brother_ql_print   = brother_ql.brother_ql_print:main",
+            "brother_ql_debug   = brother_ql.brother_ql_debug:main",
+            "brother_ql_info    = brother_ql.brother_ql_info:main",
+        ],
+    },
+    include_package_data=False,
+    zip_safe=True,
+    platforms="any",
+    install_requires=[
+        "click",
+        "packbits",
+        "pillow>=10.0.0",
+        "pyusb",
+        "attrs",
+        'typing;python_version<"3.5"',
+        'enum34;python_version<"3.4"',
+    ],
+    extras_require={
+        #'brother_ql_analyse':  ["matplotlib",],
+        #'brother_ql_create' :  ["matplotlib",],
+    },
+    keywords="Brother QL-500 QL-550 QL-560 QL-570 QL-700 QL-710W QL-720NW QL-800 QL-810W QL-820NWB QL-1050 QL-1060N",
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Operating System :: OS Independent",
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Topic :: Scientific/Engineering :: Visualization",
+        "Topic :: System :: Hardware :: Hardware Drivers",
+    ],
 )
-
-
-


### PR DESCRIPTION
Display a more readable error message by marking label and backend as required options. This gets read of the cryptic `KeyError: None` message that is hard to understand. Fixes https://github.com/pklaus/brother_ql/issues/123

Based on the formatting changes on #51, please merge that one first.