### PR TITLE
Power settings and TZe color info

### DIFF
--- a/brother_ql/backends/helpers.py
+++ b/brother_ql/backends/helpers.py
@@ -8,6 +8,7 @@ Helpers for the subpackage brother_ql.backends
 """
 
 import logging, time
+from warnings import warn
 
 from brother_ql.backends import backend_factory, guess_backend
 from brother_ql.reader import interpret_response
@@ -157,6 +158,30 @@ def get_status(
             raise ValueError(f"Printer reported 0x{result['status_code']:02x} status instead of 0x{target_status:02x}")
     return result
 
+
+def status(
+    printer_identifier=None,
+    backend_identifier=None,
+):
+    """
+    DEPRECATED
+    Retrieve status info from the printer, including model and currently loaded media size.
+    This function will be removed in a release after 2025-08-05.
+
+    :param str printer_identifier: Identifier for the printer.
+    :param str backend_identifier: Can enforce the use of a specific backend.
+    """
+    warn("The 'status' function is deprecated. Use 'get_status' instead.", DeprecationWarning, stacklevel=2)
+
+    printer = get_printer(printer_identifier, backend_identifier)
+    result = get_status(printer)
+    logger.info(f"Printer Series Code: 0x{result['series_code']:02x}")
+    logger.info(f"Printer Model Code: 0x{result['model_code']:02x}")
+    logger.info(f"Printer Status Type: {result['status_type']} ")
+    logger.info(f"Printer Phase Type: {result['phase_type']})")
+    logger.info(f"Printer Errors: {result['errors']}")
+    logger.info(f"Media Type: {result['media_type']}")
+    logger.info(f"Media Size: {result['media_width']} x {result['media_length']} mm")
 
 def get_setting(
     printer,

--- a/brother_ql/backends/helpers.py
+++ b/brother_ql/backends/helpers.py
@@ -132,121 +132,140 @@ def get_printer(
     printer = BrotherQLBackend(printer_identifier)
     return printer
 
-def status(
-    printer_identifier=None,
-    backend_identifier=None,
+def get_status(
+    printer,
+    receive_only=False,
+    target_status=None,
 ):
     """
-    Retrieve status info from the printer, including model and currently loaded media size.
+    Get printer status.
 
+    :param BrotherQLBackendGeneric printer: A printer instance.
+    :param bool receive_only: Don't send the status request command.
+    :param int target_status: Expected status code.
     """
 
-    printer=get_printer(printer_identifier, backend_identifier)
-
-    logger.info("Sending status information request to the printer.")
-    printer.write(b"\x1b\x69\x53")  # "ESC i S" Status information request
+    if not receive_only:
+        printer.write(b"\x1b\x69\x53")  # "ESC i S" Status information request
     data = printer.read()
     try:
         result = interpret_response(data)
     except ValueError:
         logger.error("Failed to parse response data: %s", data)
-
-    logger.info(f"Printer Series Code: 0x{result['series_code']:02x}")
-    logger.info(f"Printer Model Code: 0x{result['model_code']:02x}")
-    logger.info(f"Printer Status Type: {result['status_type']} ")
-    logger.info(f"Printer Phase Type: {result['phase_type']})")
-    logger.info(f"Printer Errors: {result['errors']}")
-    logger.info(f"Media Type: {result['media_type']}")
-    logger.info(f"Media Size: {result['media_width']} x {result['media_length']} mm")
-
+    if target_status is not None:
+        if result['status_code'] != target_status:
+            raise ValueError(f"Printer reported 0x{result['status_code']:02x} status instead of 0x{target_status:02x}")
     return result
+
+
+def get_setting(
+    printer,
+    setting,
+    payload=None
+):
+    """
+    Get setting from printer.
+
+    :param BrotherQLBackendGeneric printer: A printer instance.
+    :param int setting: The code for the setting.
+    :param bytes payload: Optional additional payload, usually not required.
+    """
+
+    # ensure printer is free of errors before proceeding
+    get_status(printer, target_status=0x0)
+    # switch to raster command mode
+    printer.write(b"\x1b\x69\x61\x01")
+    # send command
+    command = b"\x1b\x69\x55" + setting.to_bytes(1) + b"\x01"
+    if payload is not None:
+        command += payload
+    printer.write(command)
+    result = get_status(printer, receive_only=True, target_status=0xF0)
+    return result
+
+
+def write_setting(
+    printer,
+    setting,
+    payload,
+):
+    """
+    Write setting to printer.
+
+    :param BrotherQLBackendGeneric printer: A printer instance.
+    :param int setting: The code for the setting.
+    :param bytes payload: Payload for the setting.
+    """
+
+    # switch to raster command mode
+    printer.write(b"\x1b\x69\x61\x01")
+    # write settings
+    command = b"\x1b\x69\x55" + setting.to_bytes(1) + b"\x00"
+    command += payload
+    printer.write(command)
+    # retrieve status to make sure no errors occured
+    result = get_status(printer)
+    if result['status_code'] != 0x0:
+        raise ValueError("Failed to modify settings")
+    return result
+
 
 def configure(
     printer_identifier=None,
     backend_identifier=None,
-    write=False,
-    auto_power_off=None,
-    auto_power_on=None,
+    action="get",
+    key=None,
+    value=None,
 ):
     """
     Read or modify power settings.
 
-    :param bool write: Write configuration to printer
-    :param int auto_power_off: multiples of 10 minutes for power off, 0 means disabled
-    :param bool auto_power_on: whether to enable auto power on or not, 1 means enabled, 0 means disabled
+    :param str printer_identifier: Identifier for the printer
+    :param str backend_identifier: Can enforce the use of a specific backend
+    :param str action: Action to perform, get or set
+    :param str key: Key name for the settings
+    :param int value: Value to update for the specified key
     """
+
     printer=get_printer(printer_identifier, backend_identifier)
 
-    if write:
-        if auto_power_off is None or auto_power_on is None:
-            raise ValueError("You must provide the settings values")
-        if auto_power_off < 0 or auto_power_off > 6:
-            raise ValueError("Auto power off can only be set between 0 to 6")
-        if type(auto_power_on) is not bool:
-            raise ValueError("Auto power on is a boolean setting")
+    if action not in ['get', 'set']:
+        raise ValueError(f"Invalid action '{action}'")
+    if key not in ['power-off-delay', 'auto-power-on']:
+        raise ValueError(f"Invalid key '{key}'")
+    if action == 'set':
+        if value is None:
+            raise ValueError(f"Specify a valid value for key '{key}'")
 
-    printer.write(b"\x1b\x69\x53")  # "ESC i S" Status information request
-    data = printer.read()
-    result = interpret_response(data)
-    if result['status_type'] != 'Reply to status request':
-        raise ValueError
+    series_code = get_status(printer, target_status=0x0)['series_code']
 
-    if write:
-        # change auto power on settings
-        printer.write(b"\x1b\x69\x61\x01") # Switch to raster command mode
-        # 0x1b 0x69 0x55 settings
-        # 0x70 auto power on
-        # 0x00 write
-        # bool state
-        command = b"\x1b\x69\x55\x70\x00" + auto_power_on.to_bytes(1)
-        printer.write(command)
+    if action == 'set':
+        if key == 'auto-power-on':
+            payload = value.to_bytes(1)
+            write_setting(printer, 0x70, payload)
+            get_status(printer, 0x0)
+        elif key == 'power-off-delay':
+            payload = b''
+            # 0x30 series needs an extra byte here
+            if series_code == 0x30:
+                payload += b"\x00"
+            payload += value.to_bytes(1)
+            write_setting(printer, 0x41, payload)
+            get_status(printer, 0x0)
+        else:
+            raise ValueError(f"Key {key} is invalid")
 
-        # retrieve status to make sure no errors occured
-        printer.write(b"\x1b\x69\x53")  # "ESC i S" Status information request
-        data = printer.read()
-        result = interpret_response(data)
-        if result['status_type'] != 'Reply to status request':
-            raise ValueError("Failed to modify settings")
+    # retrieve settings
+    retrieved_val = None
+    if key == 'auto-power-on':
+        retrieved_val = get_setting(printer, 0x70)['setting']
+    elif key == 'power-off-delay':
+        payload = b''
+        # 0x30 series needs an extra byte here
+        if series_code == 0x30:
+            payload += b"\x00"
+        retrieved_val = get_setting(printer, 0x41, payload)['setting']
+    else:
+        raise ValueError(f"Key {key} is invalid")
 
-    # read auto power on settings
-    printer.write(b"\x1b\x69\x61\x01") # Switch to raster command mode
-    # 0x1b 0x69 0x55 settings
-    # 0x70 auto power on
-    # 0x01 read
-    printer.write(b"\x1b\x69\x55\x70\x01")
-    data = printer.read()
-    result = interpret_response(data)
-    if result['status_type'] != 'Settings report':
-        raise ValueError
-    logger.info(f"Auto power on: {'Enabled' if result['setting'] else 'Disabled'}")
-
-    if write:
-        # change auto power off settings
-        printer.write(b"\x1b\x69\x61\x01") # Switch to raster command mode
-        # 0x1b 0x69 0x55 settings
-        # 0x41 auto power off
-        # 0x00 write
-        # u8 multiples of 10 minutes, 0 means disabled
-        command = b"\x1b\x69\x55\x41\x00" + auto_power_off.to_bytes(1)
-        printer.write(command)
-        
-        # retrieve status to make sure no errors occured
-        printer.write(b"\x1b\x69\x53")  # "ESC i S" Status information request
-        data = printer.read()
-        result = interpret_response(data)
-        if result['status_type'] != 'Reply to status request':
-            raise ValueError("Failed to modify settings")
-
-    # read auto power off settings
-    printer.write(b"\x1b\x69\x61\x01") # Switch to raster command mode
-    # 0x1b 0x69 0x55 settings
-    # 0x41 auto power off
-    # 0x01 read
-    printer.write(b"\x1b\x69\x55\x41\x01") 
-    data = printer.read()
-    result = interpret_response(data)
-    if result['status_type'] != 'Settings report':
-        raise ValueError
-    logger.info(f"Auto power off delay: {result['setting']*10} minutes")
-
-    return result
+    print(f"{key}: {retrieved_val}")

--- a/brother_ql/backends/helpers.py
+++ b/brother_ql/backends/helpers.py
@@ -268,4 +268,5 @@ def configure(
     else:
         raise ValueError(f"Key {key} is invalid")
 
-    print(f"{key}: {retrieved_val}")
+    logger.info(f"{key}: {retrieved_val}")
+    return retrieved_val

--- a/brother_ql/backends/helpers.py
+++ b/brother_ql/backends/helpers.py
@@ -176,6 +176,10 @@ def get_setting(
     # switch to raster command mode
     printer.write(b"\x1b\x69\x61\x01")
     # send command
+    # 0x1b 0x69 0x55 setting
+    # u8 setting
+    # 0x01 read
+    # optional extra payload
     command = b"\x1b\x69\x55" + setting.to_bytes(1) + b"\x01"
     if payload is not None:
         command += payload
@@ -200,6 +204,10 @@ def write_setting(
     # switch to raster command mode
     printer.write(b"\x1b\x69\x61\x01")
     # write settings
+    # 0x1b 0x69 0x55 setting
+    # u8 setting
+    # 0x0 write
+    # payload (size dependent on setting and machine series)
     command = b"\x1b\x69\x55" + setting.to_bytes(1) + b"\x00"
     command += payload
     printer.write(command)

--- a/brother_ql/backends/helpers.py
+++ b/brother_ql/backends/helpers.py
@@ -8,7 +8,6 @@ Helpers for the subpackage brother_ql.backends
 """
 
 import logging, time
-from warnings import warn
 
 from brother_ql.backends import backend_factory, guess_backend
 from brother_ql.reader import interpret_response
@@ -158,30 +157,6 @@ def get_status(
             raise ValueError(f"Printer reported 0x{result['status_code']:02x} status instead of 0x{target_status:02x}")
     return result
 
-
-def status(
-    printer_identifier=None,
-    backend_identifier=None,
-):
-    """
-    DEPRECATED
-    Retrieve status info from the printer, including model and currently loaded media size.
-    This function will be removed in a release after 2025-08-05.
-
-    :param str printer_identifier: Identifier for the printer.
-    :param str backend_identifier: Can enforce the use of a specific backend.
-    """
-    warn("The 'status' function is deprecated. Use 'get_status' instead.", DeprecationWarning, stacklevel=2)
-
-    printer = get_printer(printer_identifier, backend_identifier)
-    result = get_status(printer)
-    logger.info(f"Printer Series Code: 0x{result['series_code']:02x}")
-    logger.info(f"Printer Model Code: 0x{result['model_code']:02x}")
-    logger.info(f"Printer Status Type: {result['status_type']} ")
-    logger.info(f"Printer Phase Type: {result['phase_type']})")
-    logger.info(f"Printer Errors: {result['errors']}")
-    logger.info(f"Media Type: {result['media_type']}")
-    logger.info(f"Media Size: {result['media_width']} x {result['media_length']} mm")
 
 def get_setting(
     printer,

--- a/brother_ql/cli.py
+++ b/brother_ql/cli.py
@@ -212,7 +212,11 @@ def status_cmd(ctx, *args, **kwargs):
     print(f"Phase: {result['phase_type']}")
     if len(result['errors']) != 0:
         print(f"Errors: {result['errors']}")
-    print(f"Media type: {result['media_type']}")
+    print(f"Media type: [{result['media_category']}] {result['media_type']}")
+    if result['media_category'] == 'TZe':
+        print("Note: tape color information may be incorrect for aftermarket tape cartridges.")
+        print(f"Tape color: {result['tape_color']}")
+        print(f"Text color: {result['text_color']}")
     print(f"Media size: {result['media_width']} x {result['media_length']} mm")
 
 

--- a/brother_ql/cli.py
+++ b/brother_ql/cli.py
@@ -217,6 +217,27 @@ def status_cmd(ctx, *args, **kwargs):
         backend_identifier=ctx.meta.get("BACKEND"),
     )
 
+@cli.command(name="configure", short_help="read and modify printer settings")
+@click.option('-w', '--write', is_flag=True, default=False, help='Write settings')
+@click.option('-on', '--auto-power-on', is_flag=True, show_default=True, default=False, help='Enable automatic power-on')
+@click.option('-off', '--power-off-delay', type=click.IntRange(0, 6), default=6, help='Automatic power-off delay in multiples of 10 minutes. Use 0 to disable automatic power-off.')
+
+@click.pass_context
+def configure_cmd(ctx, *args, **kwargs):
+    from brother_ql.backends.helpers import configure
+
+    if ctx.meta['MODEL'] is None:
+        raise ValueError("You need to provide a printer model to change printer settings.")
+    elif not ctx.meta['MODEL'].startswith("QL"):
+        raise ValueError("Only QL series printers are supported at the moment.")
+    
+    configure(
+        printer_identifier=ctx.meta.get("PRINTER"),
+        backend_identifier=ctx.meta.get("BACKEND"),
+        write=kwargs.get('write'),
+        auto_power_off=kwargs.get('power_off_delay'),
+        auto_power_on=kwargs.get('auto_power_on')
+    )
 
 if __name__ == '__main__':
     cli()

--- a/brother_ql/cli.py
+++ b/brother_ql/cli.py
@@ -57,7 +57,7 @@ def discover(ctx):
 
         # skip network discovery since it's not supported
         if backend == "pyusb" or backend == "linux_kernel":
-            print(f"Probing device at {device['identifier']}")
+            logger.info(f"Probing device at {device['identifier']}")
 
             # check permissions before accessing lp* devices
             if backend == "linux_kernel":

--- a/brother_ql/reader.py
+++ b/brother_ql/reader.py
@@ -278,7 +278,7 @@ def interpret_response(data):
         status_type = RESP_STATUS_TYPES[status_code]
         logger.debug("Status type: %s", status_type)
     else:
-        logger.error("Unknown status type %02X", status_type)
+        logger.error("Unknown status type %02X", status_code)
 
     phase_type = data[19]
     if phase_type in RESP_PHASE_TYPES:

--- a/brother_ql/reader.py
+++ b/brother_ql/reader.py
@@ -67,15 +67,74 @@ RESP_ERROR_INFORMATION_2_DEF = {
 
 RESP_MEDIA_TYPES = {
   0x00: 'No media',
-  0x01: '[TZe] Laminated tape',
-  0x03: '[TZe] Non-laminated type',
-  0x11: '[TZe] Heat-Shrink Tube (HS 2:1)',
-  0x17: '[TZe] Heat-Shrink Tube (HS 3:1)',
-  0x0A: '[DK] Continuous length tape',
-  0x0B: '[DK] Die-cut labels',
-  0x4A: '[RD] Continuous length tape',
-  0x4B: '[RD] Die-cut labels',
+  0x01: 'Laminated tape',
+  0x03: 'Non-laminated type',
+  0x11: 'Heat-Shrink Tube (HS 2:1)',
+  0x17: 'Heat-Shrink Tube (HS 3:1)',
+  0x0A: 'Continuous length tape',
+  0x0B: 'Die-cut labels',
+  0x4A: 'Continuous length tape',
+  0x4B: 'Die-cut labels',
   0xFF: 'Incompatible tape',
+}
+
+RESP_MEDIA_CATEGORIES = {
+  0x00: 'No media',
+  0x01: 'TZe',
+  0x03: 'TZe',
+  0x11: 'TZe',
+  0x17: 'TZe',
+  0x0A: 'DK',
+  0x0B: 'DK',
+  0x4A: 'RD',
+  0x4B: 'RD',
+  0xFF: 'Incompatible',
+}
+
+RESP_TAPE_COLORS = {
+  0x01: 'White',
+  0x02: 'Other',
+  0x03: 'Clear',
+  0x04: 'Red',
+  0x05: 'Blue',
+  0x06: 'Yellow',
+  0x07: 'Green',
+  0x08: 'Black',
+  0x09: 'Clear(White text)',
+  0x20: 'Matte White',
+  0x21: 'Matte Clear',
+  0x22: 'Matte Silver',
+  0x23: 'Satin Gold',
+  0x24: 'Satin Silver',
+  0x30: 'Blue(D)',
+  0x31: 'Red(D)',
+  0x40: 'Fluorescent Orange',
+  0x41: 'Fluorescent Yellow',
+  0x50: 'Berry Pink(S)',
+  0x51: 'Light Gray(S)',
+  0x52: 'Lime Green(S)',
+  0x60: 'Yellow(F)',
+  0x61: 'Pink(F)',
+  0x62: 'Blue(F)',
+  0x70: 'White(Heat-shrink Tube)',
+  0x90: 'White(Flex. ID)',
+  0x91: 'Yellow(Flex. ID)',
+  0xF0: 'Clearning',
+  0xF1: 'Stencil',
+  0xFF: 'Incompatible',
+}
+
+RESP_TEXT_COLORS = {
+  0x01: 'White',
+  0x04: 'Red',
+  0x05: 'Blue',
+  0x08: 'Black',
+  0x0A: 'Gold',
+  0x62: 'Blue(F)',
+  0xF0: 'Cleaning',
+  0xF1: 'Stencil',
+  0x02: 'Other',
+  0xFF: 'Incompatible',
 }
 
 RESP_STATUS_TYPES = {
@@ -198,11 +257,21 @@ def interpret_response(data):
     media_length = data[17]
 
     media_code = data[11]
+    media_category = ""
     if media_code in RESP_MEDIA_TYPES:
         media_type = RESP_MEDIA_TYPES[media_code]
+        media_category = RESP_MEDIA_CATEGORIES[media_code]
         logger.debug("Media type: %s", media_type)
     else:
         logger.error("Unknown media type %02X", media_code)
+
+    tape_color_code = data[24]
+    text_color_code = data[25]
+    tape_color = ''
+    text_color = ''
+    if media_category == 'TZe':
+        tape_color = RESP_TAPE_COLORS[tape_color_code]
+        text_color = RESP_TEXT_COLORS[text_color_code]
 
     status_code = data[18]
     if status_code in RESP_STATUS_TYPES:
@@ -239,7 +308,9 @@ def interpret_response(data):
       'status_code': status_code,
       'phase_type': phase_type,
       'media_type': media_type,
-      'media_code': media_code,
+      'media_category': media_category,
+      'tape_color': tape_color,
+      'text_color': text_color,
       'media_width': media_width,
       'media_length': media_length,
       'setting': setting,


### PR DESCRIPTION
The status related functions have been refactored to always detect the printer model. This will be good for implementing automatic printer detection at some point, so the model doesn't have to be specified all the time. Color information is now reported for TZe media, but a lot of aftermarket tapes use the exact same enclosure mold for all colors of the same width for cost reduction, so the color information will be incorrect for those.

```
$ brother_ql -p /dev/usb/lp0 status
Model: PT-P700
Status type: Reply to status request
Phase: Waiting to receive
Media type: [TZe] Laminated tape
Note: tape color information may be incorrect for aftermarket tape cartridges.
Tape color: Clear
Text color: Blue
Media size: 24 x 0 mm
$ brother_ql -p /dev/usb/lp1 status
Model: QL-700
Status type: Reply to status request
Phase: Waiting to receive
Media type: [DK] Continuous length tape
Media size: 62 x 0 mm
$ brother_ql -p /dev/usb/lp1 status
ERROR:brother_ql.reader:Error: Cover opened while printing (Except QL-500)
Model: QL-700
Status type: Error occurred
Phase: Waiting to receive
Errors: ['Cover opened while printing (Except QL-500)']
Media type: [DK] Continuous length tape
Media size: 62 x 0 mm
$ brother_ql -p /dev/usb/lp0 status
ERROR:brother_ql.reader:Error: Cover opened while printing (Except QL-500)
Model: PT-P700
Status type: Error occurred
Phase: Waiting to receive
Errors: ['Cover opened while printing (Except QL-500)']
Media type: [TZe] Laminated tape
Note: tape color information may be incorrect for aftermarket tape cartridges.
Tape color: Clear
Text color: Blue
Media size: 24 x 0 mm
```

---

The settings command was reverse engineered since it is not documented in the manuals. I'll attempt to explain this procedure to serve as documentation.

### Command Structure

Syntax for the "setting" command has the following structure:

`0x1b 0x69 0x55 {u8 setting} {u8 command} {u8[] payload}`

| Key  | Setting                       | Read | Write | Payload Size | Notes          |
| ---- | ----------------------------- | ---- | ----- | ------------ | -------------- |
| 0x4A | Job ID                        | N/A  | 0x00  | W(13)        | Not supported  |
| 0x77 | Additional media info         | N/A  | 0x01  | W(127)       | Not supported  |
| 0x41 | Power-off delay (0x34 series) | 0x01 | 0x00  | R(0) W(1)    | 0x0 - 0x6      |
| 0x41 | Power-off delay (0x30 series) | 0x01 | 0x00  | R(1) W(2)    | 0x0, 0x0 - 0x6 |
| 0x70 | Automatic power-on            | 0x01 | 0x00  | R(0) W(1)    | 0x0 - 0x1      |

For 0x30 series, the 0x41 command requires an extra byte as the payload:
- Read: 0x1b 0x69 0x55 0x41 0x01 **0x00**
- Write: 0x1b 0x69 0x55 0x41 0x00 **0x00** {u8 value}

### Command Sequence

Reading a setting

1. 0x1b 0x40 (init)
2. 0x1b 0x69 0x53 (status request)
3. Receive status, status type should be 0x00 with no errors
4. 0x1b 0x69 0x61 0x01 (switch to raster mode)
5. 0x1b 0x69 0x55 (settings) 0x41 (power-off delay) 0x1 (read)
6. Receive status, status type should be 0xF0 with no errors. The requested setting is at offset 0x30.

Writing a setting

1. 0x1b 0x69 0x53 (status request)
2. Receive status, status type should be 0x00 with no errors
3. 0x1b 0x69 0x61 0x01 (switch to raster mode)
4. 0x1b 0x69 0x55 (settings) 0x41 (power-off delay) 0x0 (write) 0x6 (60 minutes)
5. Receive status, status type should be 0x00 with no errors

```
$ brother_ql -p /dev/usb/lp0 configure get auto-power-on
auto-power-on: 0
$ brother_ql -p /dev/usb/lp0 configure get power-off-delay
power-off-delay: 6
$ brother_ql -p /dev/usb/lp0 configure set auto-power-on 1
auto-power-on: 1
$ brother_ql -p /dev/usb/lp0 configure set power-off-delay 0
power-off-delay: 0
$ brother_ql -p /dev/usb/lp1 configure get power-off-delay
power-off-delay: 2
$ brother_ql -p /dev/usb/lp1 configure get auto-power-on
auto-power-on: 1
$ brother_ql -p /dev/usb/lp1 configure set auto-power-on 0
auto-power-on: 0
$ brother_ql -p /dev/usb/lp1 configure set power-off-delay 0
power-off-delay: 0
$ brother_ql -p /dev/usb/lp1 configure set power-off-delay 6
power-off-delay: 6
```