### PR TITLE
P-Touch Editor Lite detection, basic compatibility checks and better error handling for pyusb

### DIFF
--- a/brother_ql/backends/generic.py
+++ b/brother_ql/backends/generic.py
@@ -4,7 +4,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def list_available_devices():
+def list_available_devices(ums_warning=True):
     """ List all available devices for the respective backend """
     # returns a list of dictionaries with the keys 'identifier' and 'instance':
     # [ {'identifier': '/dev/usb/lp0', 'instance': os.open('/dev/usb/lp0', os.O_RDWR)}, ]

--- a/brother_ql/backends/linux_kernel.py
+++ b/brother_ql/backends/linux_kernel.py
@@ -93,7 +93,7 @@ def list_available_devices(ums_warning=True):
             try:
                 model = re.search('^(?:usb-Brother_)((?:PT|QL)-[A-Z0-9]{2,5})(?:_[A-Z0-9]+-0:0-part1)$', path).group(1)
                 logger.warn(f"Detected a label printer {model} in the unsupported P-Touch Editor Lite mode.")
-            except AttributeError or IndexError:
+            except (AttributeError, IndexError):
                 logger.warn(f"Detected a label printer in the unsupported P-Touch Editor Lite mode at {path}")
             logger.warn("Disable P-Touch Editor Lite by holding down the corresponding button on the printer until the light goes off.")
 

--- a/brother_ql/backends/linux_kernel.py
+++ b/brother_ql/backends/linux_kernel.py
@@ -6,21 +6,98 @@ Works on Linux.
 """
 
 import glob, os, time, select
+import re
+import logging
+
+logger = logging.getLogger(__name__)
 
 from .generic import BrotherQLBackendGeneric
 
-def list_available_devices():
+def __parse_ieee1284_id(id):
+    # parse IEEE1284 ID info into a dictionary
+    # MFG:Brother;CMD:PT-CBP;MDL:PT-P700;CLS:PRINTER;CID:Brother LabelPrinter TypeA1;
+    # MFG:Kyocera Mita;Model:Kyocera Mita Ci-1100;COMMAND SET: POSTSCRIPT,PJL,PCL
+    elements = id.split(";")[:-1] # discard the last blank element
+    return {kv[0].casefold(): kv[1] for kv in map(lambda s: s.split(':'), elements)}
+
+def list_available_devices(ums_warning=True):
     """
-    List all available devices for the linux kernel backend
+    List all available compatible devices for the linux kernel backend
+    The function will attempt to read the IEEE1284 ID of all USB printers and verify:
+    - Manufacturer is Brother
+    - Command set is PT-CBP, aka the raster command set
+
+    :param bool ums_warning: enable warinings when printers in P-Touch Editor Lite are detected
 
     returns: devices: a list of dictionaries with the keys 'identifier' and 'instance': \
         [ {'identifier': 'file:///dev/usb/lp0', 'instance': None}, ] \
         Instance is set to None because we don't want to open (and thus potentially block) the device here.
     """
 
-    paths = glob.glob('/dev/usb/lp*')
+    all_printer_names = [re.search('(lp\d+)$', path).group(0) for path in glob.glob('/dev/usb/lp*')]
+    pt_printer_info = {}
 
-    return [{'identifier': 'file://' + path, 'instance': None} for path in paths]
+    # read printer info into a dictionary like the following:
+    # {'lp1': {'mfg': 'Brother', 'cmd': 'PT-CBP', 'mdl': 'QL-700', 'cls': 'PRINTER'}}
+    for name in all_printer_names:
+        printer_path = f"/dev/usb/{name}"
+        id_path = f"/sys/class/usbmisc/{name}/device/ieee1284_id"
+        info = None
+        try:
+            with open(id_path, "r") as f:
+                info = __parse_ieee1284_id(f.read())
+        except FileNotFoundError:
+            logger.warn(f"Unable to retrieve device info for printer {name}, cannot check for compatibility.")
+            continue
+
+        # check IEEE1284 MFG and CMD fields
+        manufacturer = ''
+        for m in 'mfg', 'manufacturer':
+            if info.get(m) is not None:
+                manufacturer = info.get(m)
+
+        model = ''
+        for m in 'model', 'mdl':
+            if info.get(m) is not None:
+                model = info.get(m)
+
+        command_set = ''
+        for c in 'cmd', 'command set':
+            if info.get(c) is not None:
+                command_set = info.get(c)
+
+        if manufacturer == 'Brother' and command_set == 'PT-CBP':
+            logger.info(f"Compatible printer at {name}: {manufacturer} {model}")
+        else:
+            logger.info(f"Inompatible printer at {name}: {manufacturer} {model}")
+            continue
+
+        # check permissions
+        if not os.access(printer_path, os.W_OK):
+            logger.info(
+                f"Cannot access device {printer_path} due to insufficient permissions. You need to be a part of the lp group to access printers with this backend."
+            )
+            continue
+
+        # if everything is ok, add printer to the list
+        pt_printer_info[name] = info
+
+    logger.debug(pt_printer_info)
+    pt_printer_names = pt_printer_info.keys()
+
+    # P-Touch Editor Lite (ums) detection
+    # look for paths created via persistent block device naming from udev
+    if ums_warning:
+        ums_paths = [os.path.basename(path) for path in glob.glob('/dev/disk/by-id/usb-Brother_*_*-0:0-part1')] 
+        for path in ums_paths:
+            try:
+                model = re.search('^(?:usb-Brother_)((?:PT|QL)-[A-Z0-9]{2,5})(?:_[A-Z0-9]+-0:0-part1)$', path).group(1)
+                logger.warn(f"Detected a label printer {model} in the unsupported P-Touch Editor Lite mode.")
+            except AttributeError or IndexError:
+                logger.warn(f"Detected a label printer in the unsupported P-Touch Editor Lite mode at {path}")
+            logger.warn("Disable P-Touch Editor Lite by holding down the corresponding button on the printer until the light goes off.")
+
+    return [{'identifier': 'file://' + '/dev/usb/' + n, 'instance': None} for n in pt_printer_names]
 
 class BrotherQLBackendLinuxKernel(BrotherQLBackendGeneric):
     """

--- a/brother_ql/backends/linux_kernel.py
+++ b/brother_ql/backends/linux_kernel.py
@@ -66,10 +66,12 @@ def list_available_devices(ums_warning=True):
             if info.get(c) is not None:
                 command_set = info.get(c)
 
-        if manufacturer == 'Brother' and command_set == 'PT-CBP':
+        logger.debug(f"Checking printer {info}")
+        if manufacturer == 'Brother' and 'PT-CBP' in command_set:
             logger.info(f"Compatible printer at {name}: {manufacturer} {model}")
         else:
             logger.info(f"Inompatible printer at {name}: {manufacturer} {model}")
+            logger.info(f"Command set: {command_set}")
             continue
 
         # check permissions

--- a/brother_ql/backends/pyusb.py
+++ b/brother_ql/backends/pyusb.py
@@ -19,9 +19,11 @@ from .generic import BrotherQLBackendGeneric
 
 BROTHER_VID = 0x04f9
 
-def list_available_devices():
+def list_available_devices(ums_warning=True):
     """
     List all available devices for the respective backend
+
+    :param bool ums_warning: enable warinings when printers in P-Touch Editor Lite are detected
 
     returns: devices: a list of dictionaries with the keys 'identifier' and 'instance': \
         [ {'identifier': 'usb://0x04f9:0x2015/C5Z315686', 'instance': pyusb.core.Device()}, ]
@@ -68,7 +70,7 @@ def list_available_devices():
                 dev.idVendor, dev.idProduct, serial
             )
 
-    if ums_printers is not None:
+    if ums_warning and ums_printers is not None:
         for p in ums_printers:
             logger.warn(f"Detected USB label printer in the unsupported P-Touch Editor Lite mode: {get_descriptor(p, p.iProduct)}")
             logger.warn("Disable P-Touch Editor Lite mode by holding down the corresponding button on the printer until the light goes off.")
@@ -97,7 +99,7 @@ class BrotherQLBackendPyUSB(BrotherQLBackendGeneric):
             vendor_product, _, serial = device_specifier.partition('/')
             vendor, _, product = vendor_product.partition(':')
             vendor, product = int(vendor, 16), int(product, 16)
-            for result in list_available_devices():
+            for result in list_available_devices(ums_warning=False):
                 printer = result['instance']
                 if printer.idVendor == vendor and printer.idProduct == product or (serial and printer.iSerialNumber == serial):
                     self.dev = printer

--- a/brother_ql/cli.py
+++ b/brother_ql/cli.py
@@ -211,7 +211,12 @@ def status_cmd(ctx, *args, **kwargs):
     if len(result['errors']) != 0:
         print(f"Errors: {result['errors']}")
     print(f"Media type: [{result['media_category']}] {result['media_type']}")
-    if result['media_category'] == 'TZe':
+    if result['model'].startswith('QL') and result['media_sensor'] != 0x0:
+        color = 'Black on White'
+        if result['media_sensor'] == 0x23:
+            color = 'Red/Black on White'
+        print(f"Media color: {color}")
+    if result['model'].startswith('PT'):
         print("Note: tape color information may be incorrect for aftermarket tape cartridges.")
         print(f"Tape color: {result['tape_color']}")
         print(f"Text color: {result['text_color']}")

--- a/brother_ql/models.py
+++ b/brother_ql/models.py
@@ -39,6 +39,8 @@ class Model(object):
     #: Number of NULL bytes needed for the invalidate command.
     num_invalidate_bytes = attrib(type=int, default=200)
     #: Hardware IDs
+    # series code and model code are obtained from the status reply sent by the printer
+    # product id is the USB PID for the printer
     series_code = attrib(type=int, default=0xFFFF)
     model_code = attrib(type=int, default=0xFFFF)
     product_id = attrib(type=int, default=0xFFFF)


### PR DESCRIPTION
1. P-Touch Editor Lite detection:
    - pyusb: check for USB Mass Storage devices with a Brother VID
    - linux_kernel: look for a persistent block device name created by udev, I've avoided pyusb and udisks on purpose to maximize compatibility
2. Compatibility checks: when running discovery with the `linux_kernel` backend, parse the IEEE1284 ID from `/sys/class/usbmisc/lpX/device/ieee1284_id` and filter for Brother printers with the `PT-CBT` command set. Incompatible printers will generate a message but won't be returned by the function. Every single USB P-Touch printer should be able to pass this check. While it's possible to do this with libusb to make sure it doesn't pick up Brother printers that aren't P-Touch devices, it's pretty complicated, so I didn't do it with libusb yet.
3. Graceful error handling with libusb. The backend will now clean up after itself when a libusb error occurs and re-attach the kernel driver if required. `0x04f9:0x0330` is a Brother printer but it's not P-Touch. It's used by `usbfs` that libusb cannot unbind due to the lack of permissions, I'm only using it to demonstrate the improved error handling.

```
$ brother_ql -b pyusb discover
WARNING:brother_ql.backends.pyusb:Detected USB label printer in the unsupported P-Touch Editor Lite mode: PT-P700
WARNING:brother_ql.backends.pyusb:Disable P-Touch Editor Lite mode by holding down the corresponding button on the printer until the light goes off.
ERROR:brother_ql.backends.pyusb:Cannot initialize device 0x04f9:0x0330/XXXXXXXXXX: [Errno 16] Resource busy
$ brother_ql -b linux_kernel discover
INFO:brother_ql.backends.linux_kernel:Compatible printer at lp0: Brother QL-700
WARNING:brother_ql.backends.linux_kernel:Detected a label printer PT-P700 in the unsupported P-Touch Editor Lite mode.
WARNING:brother_ql.backends.linux_kernel:Disable P-Touch Editor Lite by holding down the corresponding button on the printer until the light goes off.
Found compatible printer QL-700 at: file:///dev/usb/lp0
$ brother_ql -b pyusb discover
WARNING:brother_ql.backends.pyusb:Detected USB label printer in the unsupported P-Touch Editor Lite mode: PT-P700
WARNING:brother_ql.backends.pyusb:Disable P-Touch Editor Lite mode by holding down the corresponding button on the printer until the light goes off.
Found compatible printer QL-700 at: usb://0x04f9:0x2042/XXXXXXXXXX
```

Fixes https://github.com/matmair/brother_ql-inventree/issues/64