### PR TITLE
Print queue

### DIFF
--- a/brother_ql/backends/helpers.py
+++ b/brother_ql/backends/helpers.py
@@ -11,6 +11,7 @@ import logging, time
 
 from brother_ql.backends import backend_factory, guess_backend
 from brother_ql.reader import interpret_response
+from brother_ql.backends import BrotherQLBackendGeneric
 
 logger = logging.getLogger(__name__)
 
@@ -159,9 +160,9 @@ def get_status(
 
 
 def get_setting(
-    printer,
-    setting,
-    payload=None
+    printer: BrotherQLBackendGeneric,
+    setting: int,
+    payload: bytes = None,
 ):
     """
     Get setting from printer.
@@ -180,7 +181,7 @@ def get_setting(
     # u8 setting
     # 0x01 read
     # optional extra payload
-    command = b"\x1b\x69\x55" + setting.to_bytes(1) + b"\x01"
+    command = b"\x1b\x69\x55" + setting.to_bytes(1, "big") + b"\x01"
     if payload is not None:
         command += payload
     printer.write(command)
@@ -189,9 +190,9 @@ def get_setting(
 
 
 def write_setting(
-    printer,
-    setting,
-    payload,
+    printer: BrotherQLBackendGeneric,
+    setting: int,
+    payload: bytes,
 ):
     """
     Write setting to printer.
@@ -208,7 +209,7 @@ def write_setting(
     # u8 setting
     # 0x0 write
     # payload (size dependent on setting and machine series)
-    command = b"\x1b\x69\x55" + setting.to_bytes(1) + b"\x00"
+    command = b"\x1b\x69\x55" + setting.to_bytes(1, 'big') + b"\x00"
     command += payload
     printer.write(command)
     # retrieve status to make sure no errors occured
@@ -249,7 +250,7 @@ def configure(
 
     if action == 'set':
         if key == 'auto-power-on':
-            payload = value.to_bytes(1)
+            payload = value.to_bytes(1, "big")
             write_setting(printer, 0x70, payload)
             get_status(printer, 0x0)
         elif key == 'power-off-delay':
@@ -257,7 +258,7 @@ def configure(
             # 0x30 series needs an extra byte here
             if series_code == 0x30:
                 payload += b"\x00"
-            payload += value.to_bytes(1)
+            payload += value.to_bytes(1, "big")
             write_setting(printer, 0x41, payload)
             get_status(printer, 0x0)
         else:

--- a/brother_ql/conversion.py
+++ b/brother_ql/conversion.py
@@ -74,6 +74,7 @@ def convert(qlr, images, label,  **kwargs):
         pass
 
     for i, image in enumerate(images):
+        logger.info(f"Rasterizing page {qlr.page_number + 1} of {len(images)}")
         if isinstance(image, Image.Image):
             im = image
         else:
@@ -194,4 +195,6 @@ def convert(qlr, images, label,  **kwargs):
         else:
             qlr.add_print(last_page=False)
 
+        # increment page number
+        qlr.page_number += 1
     return qlr.data

--- a/brother_ql/conversion.py
+++ b/brother_ql/conversion.py
@@ -9,12 +9,13 @@ from brother_ql.devicedependent import ENDLESS_LABEL, DIE_CUT_LABEL, ROUND_DIE_C
 from brother_ql.devicedependent import label_type_specs, right_margin_addition
 from brother_ql import BrotherQLUnsupportedCmd
 from brother_ql.image_trafos import filtered_hsv
+from brother_ql.raster import BrotherQLRaster
 
 logger = logging.getLogger(__name__)
 
 logging.getLogger("PIL.PngImagePlugin").setLevel(logging.WARNING)
 
-def convert(qlr, images, label,  **kwargs):
+def _rasterize_images(qlr: BrotherQLRaster, images, label, queue: bool = False, **kwargs):
     r"""Converts one or more images to a raster instruction file.
 
     :param qlr:
@@ -66,15 +67,10 @@ def convert(qlr, images, label,  **kwargs):
         qlr.add_switch_mode()
     except BrotherQLUnsupportedCmd:
         pass
-    qlr.add_invalidate()
-    qlr.add_initialize()
-    try:
-        qlr.add_switch_mode()
-    except BrotherQLUnsupportedCmd:
-        pass
 
+    page_data = []
+    logger.info(f"Rasterizing {len(images)} pages")
     for i, image in enumerate(images):
-        logger.info(f"Rasterizing page {qlr.page_number + 1} of {len(images)}")
         if isinstance(image, Image.Image):
             im = image
         else:
@@ -108,7 +104,7 @@ def convert(qlr, images, label,  **kwargs):
             if im.size[0] != dots_printable[0]:
                 hsize = int((dots_printable[0] / im.size[0]) * im.size[1])
                 im = im.resize((dots_printable[0], hsize), Image.LANCZOS)
-                logger.warning('Need to resize the image...')
+                logger.debug('Need to resize the image...')
             if im.size[0] < device_pixel_width:
                 new_im = Image.new(im.mode, (device_pixel_width, im.size[1]), (255,)*len(im.mode))
                 new_im.paste(im, (device_pixel_width-im.size[0]-right_margin_dots, 0))
@@ -153,7 +149,6 @@ def convert(qlr, images, label,  **kwargs):
             else:
                 im = im.point(lambda x: 0 if x < threshold else 255, mode="1")
 
-        qlr.add_status_information()
         tape_size = label_specs['tape_size']
         if label_specs['kind'] in (DIE_CUT_LABEL, ROUND_DIE_CUT_LABEL):
             qlr.mtype = 0x0B
@@ -197,4 +192,32 @@ def convert(qlr, images, label,  **kwargs):
 
         # increment page number
         qlr.page_number += 1
-    return qlr.data
+
+        # add raster data to page data list and clear it
+        page_data.append(qlr.data)
+        qlr.clear()
+
+    if queue:
+        return page_data
+    else:
+        # return a single bytes object for legacy conversion method 
+        data = b''.join(page_data)
+        return data
+
+def convert(qlr: BrotherQLRaster, images, label, **kwargs):
+    # Legacy method with no queue support, returns a single bytes object
+    qlr.add_invalidate()
+    qlr.add_initialize()
+    qlr.add_status_information()
+    setup_data = qlr.data
+    qlr.clear()
+
+    page_data = _rasterize_images(qlr, images, label, **kwargs)
+    return setup_data + page_data
+
+def queue_convert(qlr: BrotherQLRaster, images, label, **kwargs):
+    # Queue conversion method, init handled by the print queue class
+    # Returns a list of bytes
+    kwargs['queue'] = True
+    page_data = _rasterize_images(qlr, images, label, **kwargs)
+    return page_data

--- a/brother_ql/print_queue.py
+++ b/brother_ql/print_queue.py
@@ -1,0 +1,195 @@
+import logging
+from collections import deque
+import time
+
+from brother_ql.reader import interpret_response
+from brother_ql.conversion import queue_convert
+from brother_ql.raster import BrotherQLRaster
+from brother_ql.backends import BrotherQLBackendGeneric
+
+
+logger = logging.getLogger(__name__)
+
+
+class BrotherPrintQueue:
+    def __init__(self, printer: BrotherQLBackendGeneric, rasterizer: BrotherQLRaster):
+        self._print_queue = deque()
+        self._qlr = rasterizer
+        self._printer = printer
+        self._printing = False
+        self.status = None
+        self.ready = False
+        self.last_error = []
+        self.page_count = 0
+        self.initialize()
+
+    def clear(self):
+        self._print_queue.clear()
+
+    def initialize(self):
+        self._qlr.clear()
+
+        # Standard init sequence
+        # Invalidate -> Initialize -> Status Request
+        self._qlr.add_invalidate()
+        self._printer.write(self._qlr.data)
+        self._qlr.clear()
+
+        self._qlr.add_initialize()
+        self._printer.write(self._qlr.data)
+        self._qlr.clear()
+
+        ready = self._validate_status(phase=0, request=True, timeout=2)
+        self._printing = False
+        self.ready = ready
+
+        self.page_count = len(self._print_queue)
+
+    def queue_image(self, **kwargs):
+        if self._printing:
+            raise RuntimeError("Can't queue images while printing")
+        # BrotherQLRaster page number starts from 0
+        self._qlr.page_number = len(self._print_queue) - 1
+        page_data = queue_convert(qlr=self._qlr, **kwargs)
+        for p in page_data:
+            self._print_queue.append(p)
+            logger.debug(
+                # f"Queued page block {' '.join( map(lambda byte: f'{byte:02X}', p))}"
+                f"Queued page block of {len(p)} bytes"
+            )
+        self.page_count = len(self._print_queue)
+
+    def submit(self, clear_on_failure: bool = False):
+        if not self.ready:
+            logger.debug("Printing has failed previously, initializing printer")
+            self.initialize()
+        self._printing = True
+        count = 0
+        qsize = len(self._print_queue)
+        logger.info(f"Submitting print queue with {qsize} pages")
+        completed = False
+        while len(self._print_queue) > 0:
+            logger.info(f"Submitting page {count+1} of {qsize}")
+            printed = self._submit_page()
+            count += 1
+            if not printed:
+                logger.warning("Page submission failed, giving up")
+                break
+
+        logger.debug("Queue processing complete")
+        remaining_pages = len(self._print_queue)
+
+        if remaining_pages != 0:
+            logger.debug(f"There are {remaining_pages} pages remaining in the queue")
+            if clear_on_failure:
+                logger.debug(f"Clearing queue with failed {remaining_pages} pages")
+                self._print_queue.clear()
+        else:
+            completed = True
+        self.ready = self._validate_status(phase=0, request=True, timeout=2)
+        if self.ready:
+            logger.debug("Printer is ready to receive data")
+        else:
+            logger.error("Printer is not ready")
+            logger.debug(self.status)
+
+        self._printing = False
+        return completed
+
+    def _submit_page(self):
+        page_data = self._print_queue[0]
+        completed = False
+
+        while not completed:
+            logger.debug(
+                f"Command data: {' '.join(map(lambda byte: f'{byte:02X}', page_data))}"
+            )
+            self._printer.write(page_data)
+
+            sts_started = False
+            sts_printed = False
+            sts_ready = False
+            logger.debug("Waiting for the printer to start printing")
+            sts_started = self._validate_status(status=6, phase=1, timeout=2)
+            if sts_started:
+                logger.debug("Printing started, waiting for completion")
+                sts_printed = self._validate_status(status=1, phase=1)
+                if sts_printed:
+                    logger.debug("Printing completed, waiting for ready status")
+                    sts_ready = self._validate_status(status=6, phase=0, timeout=2)
+                    if sts_ready:
+                        logger.debug("Printer is ready to receive data")
+                else:
+                    logger.warning("Printing started but did not finish")
+            else:
+                logger.warning("Printing failed to start")
+
+            completed = sts_started and sts_printed and sts_ready
+            if completed:
+                # Remove printed page
+                self._print_queue.popleft()
+            else:
+                break
+
+        self.page_count = len(self._print_queue)
+        return completed
+
+    def _validate_status(
+        self,
+        status: int = -1,
+        phase: int = -1,
+        timeout: int = 10,
+        request: bool = False,
+    ):
+        if request:
+            if status != -1:
+                raise AttributeError(
+                    "Specifying an expected status type is not allowed for requests"
+                )
+            status = 0  # always 0x00 for requests
+            logger.debug("Requesting status")
+            self._qlr.clear()
+            self._qlr.add_status_information()
+            self._printer.write(self._qlr.data)
+            self._qlr.clear()
+
+        logger.debug("Waiting for response")
+        if status != -1 or phase != -1:
+            logger.debug(
+                f"Expecting status type 0x{status:02X}, phase type 0x{phase:02X}, timeout {timeout}s"
+            )
+
+        start_time = time.time()
+        response = None
+        while time.time() - start_time < timeout:
+            data = self._printer.read()
+            if not data:
+                time.sleep(0.1)
+                continue
+            try:
+                response = interpret_response(data)
+                break
+            except ValueError:
+                continue
+
+        match = False
+        if response is not None:
+            self.status = response
+            if len(response["errors"]) > 0:
+                self.last_error = response["errors"]
+            status_match = status == -1 or status == response["status_code"]
+            phase_match = phase == -1 or phase == response["phase_code"]
+            match = status_match and phase_match
+            logger.debug(
+                f"Got status 0x{response['status_code']:02X}, phase 0x{response['phase_code']:02X}"
+            )
+            if match:
+                logger.debug("Response matches expected status")
+            else:
+                logger.debug("Response does not match expected status")
+        else:
+            logger.warning(
+                f"Did not receive a response from printer within {timeout} seconds"
+            )
+
+        return match

--- a/brother_ql/raster.py
+++ b/brother_ql/raster.py
@@ -278,3 +278,6 @@ class BrotherQLRaster(object):
             self.data += b'\x1A' # 0x1A = ^Z = SUB; here: EOF = End of File
         else:
             self.data += b'\x0C' # 0x0C = FF  = Form Feed
+
+    def clear(self):
+        self.data = b''

--- a/brother_ql/reader.py
+++ b/brother_ql/reader.py
@@ -100,6 +100,7 @@ RESP_MEDIA_CATEGORIES = {
 }
 
 RESP_TAPE_COLORS = {
+  0x00: 'No Media',
   0x01: 'White',
   0x02: 'Other',
   0x03: 'Clear',
@@ -133,6 +134,7 @@ RESP_TAPE_COLORS = {
 }
 
 RESP_TEXT_COLORS = {
+  0x00: 'No Media',
   0x01: 'White',
   0x04: 'Red',
   0x05: 'Blue',
@@ -297,12 +299,13 @@ def interpret_response(data):
     else:
         logger.error("Unknown status type %02X", status_code)
 
-    phase_type = data[19]
-    if phase_type in RESP_PHASE_TYPES:
-        phase_type = RESP_PHASE_TYPES[phase_type]
+    phase_code = data[19]
+    phase_type = ''
+    if phase_code in RESP_PHASE_TYPES:
+        phase_type = RESP_PHASE_TYPES[phase_code]
         logger.debug("Phase type: %s", phase_type)
     else:
-        logger.error("Unknown phase type %02X", phase_type)
+        logger.error("Unknown phase type %02X", phase_code)
 
     # settings report
     setting = None
@@ -317,6 +320,7 @@ def interpret_response(data):
       'status_type': status_type,
       'status_code': status_code,
       'phase_type': phase_type,
+      'phase_code': phase_code,
       'media_type': media_type,
       'media_category': media_category,
       'media_sensor': media_sensor,


### PR DESCRIPTION
Implement a simple print queue to properly handle the buffer overflow issue when a lot of labels need to be printed in one pass. Raster data should always be sent on a page-by page basis to match the behavior of P-Touch. Partially addresses #71.

The network backend is not supported for the moment due to the lack of support for status requests. Resumption is not supported in the `brother_ql` CLI, but a snippet has been provided to demonstrate how to resume printing in a script after the error has been cleared. Tested on PT-P700 and QL-810W.

## CLI invocation
```
$ brother_ql -b pyusb -p usb://0x04f9:0x2061 --model PT-P700 print -l pt12 -q -c test.png test.png test.png
INFO:brother_ql.conversion:Rasterizing 3 pages
INFO:brother_ql.print_queue:Submitting print queue with 3 pages
INFO:brother_ql.print_queue:Submitting page 1 of 3
INFO:brother_ql.print_queue:Submitting page 2 of 3
INFO:brother_ql.print_queue:Submitting page 3 of 3
```

## Example code snippet
```py
import logging
from brother_ql.backends.helpers import get_printer
from brother_ql.raster import BrotherQLRaster
from brother_ql.print_queue import BrotherPrintQueue

logging.basicConfig(level=logging.INFO)

backend = "pyusb"
model = "PT-P700"
printer = "usb://0x04f9:0x2061"
label = "pt12"

qlr = BrotherQLRaster(model)
printer_instance = get_printer(printer_identifier=printer, backend_identifier=backend)
queue = BrotherPrintQueue(printer_instance, qlr)

print("Open the cover while printing to generate an error")

f = open("test.png", "rb")
queue.queue_image(label=label, images=[f, f, f], compress=True)
success = queue.submit()

if not success:
    print("Errors: " + "".join(queue.last_error))
    print(f"There are {queue.page_count} pages remaining in the queue")
    print("Queuing another two images")
    queue.queue_image(label=label, images=[f, f], compress=True)
    input("Clear the error and press Enter to resubmit the print queue")
    success = queue.submit()
```

```
$ python test.py
Open the cover while printing to generate an error
INFO:brother_ql.conversion:Rasterizing 3 pages
INFO:brother_ql.print_queue:Submitting print queue with 3 pages
INFO:brother_ql.print_queue:Submitting page 1 of 3
ERROR:brother_ql.reader:Error: Cover opened while printing (Except QL-500)
WARNING:brother_ql.print_queue:Printing started but did not finish
WARNING:brother_ql.print_queue:Page submission failed, giving up
ERROR:brother_ql.reader:Error: Cover opened while printing (Except QL-500)
ERROR:brother_ql.print_queue:Printer is not ready
Errors: Cover opened while printing (Except QL-500)
There are 3 pages remaining in the queue
Queuing another two images
INFO:brother_ql.conversion:Rasterizing 2 pages
Clear the error and press Enter to resubmit the print queue
INFO:brother_ql.print_queue:Submitting print queue with 5 pages
INFO:brother_ql.print_queue:Submitting page 1 of 5
INFO:brother_ql.print_queue:Submitting page 2 of 5
INFO:brother_ql.print_queue:Submitting page 3 of 5
INFO:brother_ql.print_queue:Submitting page 4 of 5
INFO:brother_ql.print_queue:Submitting page 5 of 5
```