### PR TITLE
Add type hints and replace deprecated pillow constants

### DIFF
--- a/brother_ql/backends/__init__.py
+++ b/brother_ql/backends/__init__.py
@@ -8,7 +8,7 @@ available_backends = [
   'linux_kernel',
 ]
 
-def guess_backend(identifier):
+def guess_backend(identifier: str) -> str:
     """ guess the backend from a given identifier string for the device """
     if identifier.startswith('usb://') or identifier.startswith('0x'):
         return 'pyusb'
@@ -20,7 +20,7 @@ def guess_backend(identifier):
         raise ValueError('Cannot guess backend for given identifier: %s' % identifier)
     
 
-def backend_factory(backend_name):
+def backend_factory(backend_name: str) -> dict:
 
     if backend_name == 'pyusb':
         from . import pyusb        as pyusb_backend

--- a/brother_ql/backends/generic.py
+++ b/brother_ql/backends/generic.py
@@ -1,10 +1,8 @@
-
-
 import logging
 
 logger = logging.getLogger(__name__)
 
-def list_available_devices(ums_warning=True):
+def list_available_devices(ums_warning: bool = True) -> list:
     """ List all available devices for the respective backend """
     # returns a list of dictionaries with the keys 'identifier' and 'instance':
     # [ {'identifier': '/dev/usb/lp0', 'instance': os.open('/dev/usb/lp0', os.O_RDWR)}, ]
@@ -13,7 +11,7 @@ def list_available_devices(ums_warning=True):
 
 class BrotherQLBackendGeneric(object):
 
-    def __init__(self, device_specifier):
+    def __init__(self, device_specifier: str):
         """
         device_specifier can be either a string or an instance
         of the required class type.
@@ -22,17 +20,17 @@ class BrotherQLBackendGeneric(object):
         self.read_dev  = None
         raise NotImplementedError()
 
-    def _write(self, data):
+    def _write(self, data: bytes):
         self.write_dev.write(data)
 
-    def _read(self, length=32):
+    def _read(self, length: int = 32) -> bytes:
         return bytes(self.read_dev.read(length))
 
-    def write(self, data):
+    def write(self, data: bytes):
         logger.debug('Writing %d bytes.', len(data))
         self._write(data)
 
-    def read(self, length=32):
+    def read(self, length: int = 32) -> bytes:
         try:
             ret_bytes = self._read(length)
             if ret_bytes: logger.debug('Read %d bytes.', len(ret_bytes))
@@ -52,3 +50,6 @@ class BrotherQLBackendGeneric(object):
 
     def __del__(self):
         self.dispose()
+
+    def list_available_devices(self) -> list:
+        raise NotImplementedError()

--- a/brother_ql/backends/helpers.py
+++ b/brother_ql/backends/helpers.py
@@ -15,7 +15,7 @@ from brother_ql.backends import BrotherQLBackendGeneric
 
 logger = logging.getLogger(__name__)
 
-def discover(backend_identifier='linux_kernel'):
+def discover(backend_identifier: str = 'linux_kernel') -> list:
     if backend_identifier is None:
         logger.info("Backend for discovery not specified, defaulting to linux_kernel.")
         backend_identifier = "linux_kernel"
@@ -25,7 +25,7 @@ def discover(backend_identifier='linux_kernel'):
     available_devices = list_available_devices()
     return available_devices
 
-def send(instructions, printer_identifier=None, backend_identifier=None, blocking=True):
+def send(instructions: bytes, printer_identifier: str = None, backend_identifier: str = None, blocking: bool = True):
     """
     Send instruction bytes to a printer.
 
@@ -56,7 +56,7 @@ def send(instructions, printer_identifier=None, backend_identifier=None, blockin
     list_available_devices = be['list_available_devices']
     BrotherQLBackend       = be['backend_class']
 
-    printer = BrotherQLBackend(printer_identifier)
+    printer: BrotherQLBackendGeneric = BrotherQLBackend(printer_identifier)
 
     start = time.time()
     logger.info('Sending instructions to the printer. Total: %d bytes.', len(instructions))
@@ -105,9 +105,9 @@ def send(instructions, printer_identifier=None, backend_identifier=None, blockin
     return status
 
 def get_printer(
-    printer_identifier=None,
-    backend_identifier=None,
-):
+    printer_identifier: str = None,
+    backend_identifier: str = None,
+) -> BrotherQLBackendGeneric:
     """
     Instantiate a printer object for communication. Only bidirectional transport backends are supported.
 
@@ -134,10 +134,10 @@ def get_printer(
     return printer
 
 def get_status(
-    printer,
-    receive_only=False,
-    target_status=None,
-):
+    printer: BrotherQLBackendGeneric,
+    receive_only: bool = False,
+    target_status: int = None,
+) -> dict:
     """
     Get printer status.
 
@@ -146,6 +146,7 @@ def get_status(
     :param int target_status: Expected status code.
     """
 
+    result = {}
     if not receive_only:
         printer.write(b"\x1b\x69\x53")  # "ESC i S" Status information request
     data = printer.read()
@@ -163,7 +164,7 @@ def get_setting(
     printer: BrotherQLBackendGeneric,
     setting: int,
     payload: bytes = None,
-):
+) -> dict:
     """
     Get setting from printer.
 
@@ -193,7 +194,7 @@ def write_setting(
     printer: BrotherQLBackendGeneric,
     setting: int,
     payload: bytes,
-):
+) -> dict:
     """
     Write setting to printer.
 

--- a/brother_ql/backends/linux_kernel.py
+++ b/brother_ql/backends/linux_kernel.py
@@ -13,14 +13,14 @@ logger = logging.getLogger(__name__)
 
 from .generic import BrotherQLBackendGeneric
 
-def __parse_ieee1284_id(id):
+def __parse_ieee1284_id(id: str) -> dict:
     # parse IEEE1284 ID info into a dictionary
     # MFG:Brother;CMD:PT-CBP;MDL:PT-P700;CLS:PRINTER;CID:Brother LabelPrinter TypeA1;
     # MFG:Kyocera Mita;Model:Kyocera Mita Ci-1100;COMMAND SET: POSTSCRIPT,PJL,PCL
     elements = id.split(";")[:-1] # discard the last blank element
     return {kv[0].casefold(): kv[1] for kv in map(lambda s: s.split(':'), elements)}
 
-def list_available_devices(ums_warning=True):
+def list_available_devices(ums_warning: bool = True) -> list:
     """
     List all available compatible devices for the linux kernel backend
     The function will attempt to read the IEEE1284 ID of all USB printers and verify:
@@ -106,7 +106,7 @@ class BrotherQLBackendLinuxKernel(BrotherQLBackendGeneric):
     BrotherQL backend using the Linux Kernel USB Printer Device Handles
     """
 
-    def __init__(self, device_specifier):
+    def __init__(self, device_specifier: str | int):
         """
         device_specifier: string or os.open(): identifier in the \
             format file:///dev/usb/lp0 or os.open() raw device handle.
@@ -127,10 +127,10 @@ class BrotherQLBackendLinuxKernel(BrotherQLBackendGeneric):
         self.write_dev = self.dev
         self.read_dev  = self.dev
 
-    def _write(self, data):
+    def _write(self, data: bytes):
         os.write(self.write_dev, data)
 
-    def _read(self, length=32):
+    def _read(self, length: int = 32) -> bytes:
         if self.strategy == 'try_twice':
             data = os.read(self.read_dev, length)
             if data:

--- a/brother_ql/backends/network.py
+++ b/brother_ql/backends/network.py
@@ -20,14 +20,14 @@ def list_available_devices():
 
     # We need some snmp request sent to 255.255.255.255 here
     raise NotImplementedError()
-    return [{'identifier': 'tcp://' + path, 'instance': None} for path in paths]
+    # return [{'identifier': 'tcp://' + path, 'instance': None} for path in paths]
 
 class BrotherQLBackendNetwork(BrotherQLBackendGeneric):
     """
     BrotherQL backend using the Linux Kernel USB Printer Device Handles
     """
 
-    def __init__(self, device_specifier):
+    def __init__(self, device_specifier: str | int):
         """
         device_specifier: string or os.open(): identifier in the \
             format file:///dev/usb/lp0 or os.open() raw device handle.
@@ -62,12 +62,12 @@ class BrotherQLBackendNetwork(BrotherQLBackendGeneric):
         else:
             raise NotImplementedError('Currently the printer can be specified either via an appropriate string or via an os.open() handle.')
 
-    def _write(self, data):
+    def _write(self, data: bytes):
         self.s.settimeout(10)
         self.s.sendall(data)
         self.s.settimeout(self.read_timeout)
 
-    def _read(self, length=32):
+    def _read(self, length: int = 32) -> bytes:
         if self.strategy in ('socket_timeout', 'try_twice'):
             if self.strategy == 'socket_timeout':
                 tries = 1

--- a/brother_ql/brother_ql_create.py
+++ b/brother_ql/brother_ql_create.py
@@ -5,6 +5,7 @@ import sys, argparse, logging
 from brother_ql.raster import BrotherQLRaster
 from brother_ql.conversion import convert
 from brother_ql.devicedependent import label_type_specs
+from brother_ql.exceptions import BrotherQLUnknownModel
 
 try:
     stdout = sys.stdout.buffer

--- a/brother_ql/brother_ql_debug.py
+++ b/brother_ql/brother_ql_debug.py
@@ -5,6 +5,7 @@ from pprint import pprint, pformat
 
 from brother_ql.reader import OPCODES, chunker, merge_specific_instructions, interpret_response, match_opcode, hex_format
 from brother_ql.backends import backend_factory, guess_backend
+from brother_ql.backends import BrotherQLBackendGeneric
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +14,7 @@ class BrotherQL_USBdebug(object):
     def __init__(self, dev, instructions_data, backend='linux_kernel'):
 
         be_cls = backend_factory(backend)['backend_class']
-        self.be = be_cls(dev)
+        self.be: BrotherQLBackendGeneric = be_cls(dev)
 
         self.sleep_time = 0.0
         self.sleep_before_read = 0.0

--- a/brother_ql/cli.py
+++ b/brother_ql/cli.py
@@ -25,7 +25,7 @@ printer_help = "The identifier for the printer. This could be a string like tcp:
 @click.option('--debug', is_flag=True)
 @click.version_option()
 @click.pass_context
-def cli(ctx, *args, **kwargs):
+def cli(ctx: click.Context, *args, **kwargs):
     """ Command line interface for the brother_ql Python package. """
 
     backend = kwargs.get('backend', None)
@@ -43,7 +43,7 @@ def cli(ctx, *args, **kwargs):
 
 @cli.command()
 @click.pass_context
-def discover(ctx):
+def discover(ctx: click.Context):
     """ find connected label printers """
     backend = ctx.meta.get('BACKEND', 'pyusb')
     if backend is None:
@@ -83,12 +83,12 @@ def discover_and_list_available_devices(backend):
 
 @cli.group()
 @click.pass_context
-def info(ctx, *args, **kwargs):
+def info(ctx: click.Context, *args, **kwargs):
     """ list available labels, models etc. """
 
 @info.command(name='models')
 @click.pass_context
-def models_cmd(ctx, *args, **kwargs):
+def models_cmd(ctx: click.Context, *args, **kwargs):
     """
     List the choices for --model
     """
@@ -97,7 +97,7 @@ def models_cmd(ctx, *args, **kwargs):
 
 @info.command()
 @click.pass_context
-def labels(ctx, *args, **kwargs):
+def labels(ctx: click.Context, *args, **kwargs):
     """
     List the choices for --label
     """
@@ -106,7 +106,7 @@ def labels(ctx, *args, **kwargs):
 
 @info.command()
 @click.pass_context
-def env(ctx, *args, **kwargs):
+def env(ctx: click.Context, *args, **kwargs):
     """
     print debug info about running environment
     """
@@ -160,7 +160,7 @@ def env(ctx, *args, **kwargs):
 @click.option('--no-cut', is_flag=True, help="Don't cut the tape after printing the label.")
 @click.option('-q', '--queue', is_flag=True, help='Enable print queue support.')
 @click.pass_context
-def print_cmd(ctx, *args, **kwargs):
+def print_cmd(ctx: click.Context, *args, **kwargs):
     """ Print a label of the provided IMAGE. """
     backend = ctx.meta.get('BACKEND', 'pyusb')
     model = ctx.meta.get('MODEL')
@@ -189,7 +189,7 @@ def print_cmd(ctx, *args, **kwargs):
 @click.argument('instructions', type=click.File('rb'))
 @click.option('-f', '--filename-format', help="Filename format string. Default is: label{counter:04d}.png.")
 @click.pass_context
-def analyze_cmd(ctx, *args, **kwargs):
+def analyze_cmd(ctx: click.Context, *args, **kwargs):
     from brother_ql.reader import BrotherQLReader
     br = BrotherQLReader(kwargs.get('instructions'))
     if kwargs.get('filename_format'): br.filename_fmt = kwargs.get('filename_format')
@@ -198,14 +198,14 @@ def analyze_cmd(ctx, *args, **kwargs):
 @cli.command(name='send', short_help='send an instruction file to the printer')
 @click.argument('instructions', type=click.File('rb'))
 @click.pass_context
-def send_cmd(ctx, *args, **kwargs):
+def send_cmd(ctx: click.Context, *args, **kwargs):
     from brother_ql.backends.helpers import send
     send(instructions=kwargs['instructions'].read(), printer_identifier=ctx.meta.get('PRINTER'), backend_identifier=ctx.meta.get('BACKEND'), blocking=True)
 
 
 @cli.command(name="status", short_help="query printer status and the loaded media size")
 @click.pass_context
-def status_cmd(ctx, *args, **kwargs):
+def status_cmd(ctx: click.Context, *args, **kwargs):
     from brother_ql.backends.helpers import get_status, get_printer
 
     printer=get_printer(ctx.meta.get("PRINTER"), ctx.meta.get("BACKEND"))
@@ -239,7 +239,7 @@ def status_cmd(ctx, *args, **kwargs):
 @click.argument('key', required=True, type=click.Choice(['power-off-delay', 'auto-power-on']), metavar='[KEY]')
 @click.argument('value', type=int, metavar='[VALUE]', default=-1)
 @click.pass_context
-def configure_cmd(ctx, *args, **kwargs):
+def configure_cmd(ctx: click.Context, *args, **kwargs):
     from brother_ql.backends.helpers import configure
 
     if kwargs.get('action') == 'set' and kwargs.get('value') == -1:

--- a/brother_ql/conversion.py
+++ b/brother_ql/conversion.py
@@ -103,7 +103,7 @@ def _rasterize_images(qlr: BrotherQLRaster, images, label, queue: bool = False, 
                 im = im.resize((im.size[0]//2, im.size[1]))
             if im.size[0] != dots_printable[0]:
                 hsize = int((dots_printable[0] / im.size[0]) * im.size[1])
-                im = im.resize((dots_printable[0], hsize), Image.LANCZOS)
+                im = im.resize((dots_printable[0], hsize), Image.Resampling.LANCZOS)
                 logger.debug('Need to resize the image...')
             if im.size[0] < device_pixel_width:
                 new_im = Image.new(im.mode, (device_pixel_width, im.size[1]), (255,)*len(im.mode))
@@ -145,7 +145,7 @@ def _rasterize_images(qlr: BrotherQLRaster, images, label, queue: bool = False, 
             im = PIL.ImageOps.invert(im)
 
             if dither:
-                im = im.convert("1", dither=Image.FLOYDSTEINBERG)
+                im = im.convert("1", dither=Image.Dither.FLOYDSTEINBERG)
             else:
                 im = im.point(lambda x: 0 if x < threshold else 255, mode="1")
 

--- a/brother_ql/image_trafos.py
+++ b/brother_ql/image_trafos.py
@@ -1,7 +1,7 @@
 from PIL import Image
 import colorsys
 
-def filtered_hsv(im, filter_h, filter_s, filter_v, default_col=(255,255,255)):
+def filtered_hsv(im: Image.Image, filter_h: int, filter_s: int, filter_v: int, default_col=(255,255,255)) -> Image.Image:
     """ https://stackoverflow.com/a/22237709/183995 """
 
     hsv_im = im.convert('HSV')

--- a/brother_ql/raster.py
+++ b/brother_ql/raster.py
@@ -15,7 +15,7 @@ from PIL import Image
 import io
 
 from brother_ql.models import ModelsManager
-from .devicedependent import models, \
+from brother_ql.devicedependent import models, \
                              min_max_feed, \
                              min_max_length_dots, \
                              number_bytes_per_row, \
@@ -25,7 +25,7 @@ from .devicedependent import models, \
                              two_color_support, \
                              modesetting
 
-from . import BrotherQLError, BrotherQLUnsupportedCmd, BrotherQLUnknownModel, BrotherQLRasterError
+from brother_ql.exceptions import BrotherQLError, BrotherQLUnsupportedCmd, BrotherQLUnknownModel, BrotherQLRasterError
 from io import BytesIO
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ class BrotherQLRaster(object):
     :ivar bool exception_on_warning: If set to True, an exception is raised if trying to add instruction which are not supported on the selected model. If set to False, the instruction is simply ignored and a warning sent to logging/stderr.
     """
 
-    def __init__(self, model='QL-500'):
+    def __init__(self, model: str = 'QL-500'):
         if model not in models:
             raise BrotherQLUnknownModel()
         self.model = model
@@ -164,14 +164,14 @@ class BrotherQLRaster(object):
         self.data += b'\x00'
         # INFO:  media/quality (1B 69 7A) --> found! (payload: 8E 0A 3E 00 D2 00 00 00 00 00)
 
-    def add_autocut(self, autocut = False):
+    def add_autocut(self, autocut: bool = False):
         if self.model not in cuttingsupport:
             self._unsupported("Trying to call add_autocut with a printer that doesn't support it")
             return
         self.data += b'\x1B\x69\x4D' # ESC i M
         self.data += bytes([autocut << 6])
 
-    def add_cut_every(self, n=1):
+    def add_cut_every(self, n: int = 1):
         if self.model not in cuttingsupport:
             self._unsupported("Trying to call add_cut_every with a printer that doesn't support it")
             return
@@ -199,11 +199,11 @@ class BrotherQLRaster(object):
             flags |= self.two_color_printing << 0
         self.data += bytes([flags])
 
-    def add_margins(self, dots=0x23):
+    def add_margins(self, dots: int = 0x23):
         self.data += b'\x1B\x69\x64' # ESC i d
         self.data += struct.pack('<H', dots)
 
-    def add_compression(self, compression=True):
+    def add_compression(self, compression: bool = True):
         """
         Add an instruction enabling or disabling compression for the transmitted raster image lines.
         Not all models support compression. If the specific model doesn't support it but this method
@@ -226,7 +226,7 @@ class BrotherQLRaster(object):
             nbpr = number_bytes_per_row['default']
         return nbpr*8
 
-    def add_raster_data(self, image, second_image=None):
+    def add_raster_data(self, image: Image.Image, second_image: Image.Image | None = None):
         """
         Add the image data to the instructions.
         The provided image has to be binary (every pixel
@@ -273,7 +273,7 @@ class BrotherQLRaster(object):
             start += row_len
         self.data += file_str.getvalue()
 
-    def add_print(self, last_page=True):
+    def add_print(self, last_page: bool = True):
         if last_page:
             self.data += b'\x1A' # 0x1A = ^Z = SUB; here: EOF = End of File
         else:

--- a/brother_ql/reader.py
+++ b/brother_ql/reader.py
@@ -198,10 +198,10 @@ RESP_BYTE_NAMES = [
   'Reserved',
 ]
 
-def hex_format(data):
+def hex_format(data: bytes) -> str:
     return ' '.join('{:02X}'.format(byte) for byte in data)
 
-def chunker(data, raise_exception=False):
+def chunker(data, raise_exception: bool = False):
     """
     Breaks data stream (bytes) into a list of bytes objects containing single instructions each.
 
@@ -236,12 +236,12 @@ def chunker(data, raise_exception=False):
         data = data[num_bytes:]
     #return instructions
 
-def match_opcode(data):
+def match_opcode(data: bytes):
     matching_opcodes = [opcode for opcode in OPCODES.keys() if data.startswith(opcode)]
     assert len(matching_opcodes) == 1
     return matching_opcodes[0]
 
-def interpret_response(data):
+def interpret_response(data: bytes) -> dict:
     data = bytes(data)
     if len(data) < 32:
         raise NameError('Insufficient amount of data received', hex_format(data))
@@ -334,7 +334,7 @@ def interpret_response(data):
     return response
 
 
-def merge_specific_instructions(chunks, join_preamble=True, join_raster=True):
+def merge_specific_instructions(chunks, join_preamble: bool = True, join_raster: bool = True):
     """
     Process a list of instructions by merging subsequent instuctions with
     identical opcodes into "large instructions".

--- a/brother_ql/reader.py
+++ b/brother_ql/reader.py
@@ -469,7 +469,7 @@ class BrotherQLReader(object):
                                         pixdata_black[x, y] = (255, 255, 255, 0)
                             im_red.paste(im_black, (0, 0), im_black)
                             im = im_red
-                        im = im.transpose(Image.FLIP_LEFT_RIGHT)
+                        im = im.transpose(Image.Transpose.FLIP_LEFT_RIGHT)
                         img_name = self.filename_fmt.format(counter=self.page_counter)
                         im.save(img_name)
                         print('Page saved as {}'.format(img_name))


### PR DESCRIPTION
Added type hints to most functions to make auto-complete will work properly in most IDEs. Also replaced the lingering deprecated pillow constants with the updated ones, so brother-ql doesn't stop working when pillow randomly decides to remove stuff without adequate warning once again.