### PR TITLE
fix brother_ql_create

### DIFF
--- a/brother_ql/brother_ql_create.py
+++ b/brother_ql/brother_ql_create.py
@@ -46,14 +46,14 @@ def main():
 
     qlr.exception_on_warning = True
 
-    create_label(qlr, args.image, args.label_size, threshold=args.threshold, cut=args.cut, rotate=args.rotate, dither=args.dither, compress=args.compress, red=args.red, dpi_600=args.dpi_600, hq=args.hq)
+    label_data = create_label(qlr, args.image, args.label_size, threshold=args.threshold, cut=args.cut, rotate=args.rotate, dither=args.dither, compress=args.compress, red=args.red, dpi_600=args.dpi_600, hq=args.hq)
 
-    args.outfile.write(qlr.data)
+    args.outfile.write(label_data)
 
 def create_label(qlr, image, label_size, threshold=70, cut=True, dither=False, compress=False, red=False, **kwargs):
     if not isinstance(image, list):
         image = [image]
-    convert(qlr, image, label_size, threshold=threshold, cut=cut, dither=dither, compress=compress, red=red, **kwargs)
+    return convert(qlr, image, label_size, threshold=threshold, cut=cut, dither=dither, compress=compress, red=red, **kwargs)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Turns out `brother_ql_create` command doesn't actually do anything (it always produces empty file). This is because:
1) it attempts to [write `qlr.data` to outfile](https://github.com/matmair/brother_ql-inventree/blob/master/brother_ql/brother_ql_create.py#L51)
2) which is created by [`create_label`](https://github.com/matmair/brother_ql-inventree/blob/master/brother_ql/brother_ql_create.py#L49), which in turn [calls `convert`](https://github.com/matmair/brother_ql-inventree/blob/master/brother_ql/brother_ql_create.py#L56), which [calls `_rasterize_images`](https://github.com/matmair/brother_ql-inventree/blob/master/brother_ql/conversion.py#L215)
3) however, `_rasterize_images` actually [clears qlr](https://github.com/matmair/brother_ql-inventree/blob/master/brother_ql/conversion.py#L198) and [returns `bytes`](https://github.com/matmair/brother_ql-inventree/blob/master/brother_ql/conversion.py#L200-L205)

However, this return value is [never returned from `create_label`](https://github.com/matmair/brother_ql-inventree/blob/master/brother_ql/brother_ql_create.py#L56). This ABI missmatch effectively makes `brother_ql_create` useless.